### PR TITLE
Release candidate 2 for 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.1
   - 7.0
   - 5.6
 # - hhvm

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.4",
         "diablomedia/phpunit-pretty-printer": "^1.0",
-        "ext-pdo_sqlite": "*"
+        "ext-pdo_sqlite": "*",
+        "doctrine/dbal": ">=2.0"
     }
 }

--- a/src/DB.php
+++ b/src/DB.php
@@ -33,7 +33,8 @@ use Pineapple\DB\Driver\DriverInterface;
  * common to all parts of DB.
  *
  * The object model of DB is as follows (indentation means inheritance):
- * <pre>
+ *
+ * ```
  * DB The main DB class.  This is simply a utility class
  *    with some "static" methods for creating DB objects as
  *    well as common utility functions for other DB classes.
@@ -47,7 +48,7 @@ use Pineapple\DB\Driver\DriverInterface;
  *                           When calling DB::factory or DB::connect for MySQL
  *                           connections, the object returned is an instance of this
  *                           class.
- * </pre>
+ * ```
  *
  * @category   Database
  * @package    DB
@@ -206,8 +207,8 @@ class DB
     /**
      * The type of information to return from the tableInfo() method.
      *
-     * Bitwised constants, so they can be combined using <kbd>|</kbd>
-     * and removed using <kbd>^</kbd>.
+     * Bitwised constants, so they can be combined using `|`
+     * and removed using `^`.
      *
      * @see DB\Driver\Common::tableInfo()
      *
@@ -228,8 +229,8 @@ class DB
     /**
      * Portability Modes.
      *
-     * Bitwised constants, so they can be combined using <kbd>|</kbd>
-     * and removed using <kbd>^</kbd>.
+     * Bitwised constants, so they can be combined using `|`
+     * and removed using `^`.
      *
      * @see DB\Driver\Common::setOption()
      *
@@ -303,7 +304,7 @@ class DB
      *
      * @param string $type     the database driver name (eg "PdoDriver")
      * @param array  $options  an associative array of option names and values
-     * @return object          a new DB object. A DB\Error object on failure.
+     * @return DriverInterface a new DB object. A DB\Error object on failure.
      *
      * @see DB\Driver\Common::setOption()
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -358,7 +359,6 @@ class DB
      * Determines if a variable is a DB\Error object
      *
      * @param mixed $value  the variable to check
-     *
      * @return bool  whether $value is DB\Error object
      */
     public static function isError($value)
@@ -370,8 +370,7 @@ class DB
      * Determines if a value is a DB_<driver> object
      *
      * @param mixed $value  the value to test
-     *
-     * @return bool  whether $value is a DB_<driver> object
+     * @return boolean      whether $value is a DB_<driver> object
      */
     public static function isConnection($value)
     {
@@ -381,10 +380,9 @@ class DB
     /**
      * Return a textual error message for a DB error code
      *
-     * @param integer|DB\Error $value  the DB error code
-     *
-     * @return string  the error message or false if the error code was
-     *                  not recognized
+     * @param integer|DB\Error $value the DB error code
+     * @return string                 the error message or false if the error code was
+     *                                not recognized
      */
     public static function errorMessage($value)
     {

--- a/src/DB.php
+++ b/src/DB.php
@@ -253,21 +253,11 @@ class DB
     // @const Enable hack that makes numRows() work in Oracle
     const DB_PORTABILITY_NUMROWS = 8;
 
-    /**
-     * Makes certain error messages in certain drivers compatible
-     * with those from other DBMS's
-     *
-     * + mysql, mysqli:  change unique/primary key constraints
-     *   DB_ERROR_ALREADY_EXISTS -> DB_ERROR_CONSTRAINT
-     */
-    // @const Convert error messages to a consistent type across DB layers
-    const DB_PORTABILITY_ERRORS = 16;
-
     // @const Convert null values to empty strings in data output by get*() and fetch*()
     const DB_PORTABILITY_NULL_TO_EMPTY = 32;
 
     // @const Turn on all portability features
-    const DB_PORTABILITY_ALL = 63;
+    const DB_PORTABILITY_ALL = 47;
 
     // @const Driver class namespace prefix
     const INTERNAL_DRIVER_PREFIX = '\\Pineapple\\DB\\Driver\\';
@@ -312,22 +302,15 @@ class DB
      * connect to the database
      *
      * @param string $type     the database driver name (eg "PdoDriver")
-     * @param mixed  $options  an associative array of option names and values,
-     *                         or a true/false value for the 'persistent'
-     *                         option
-     *
+     * @param array  $options  an associative array of option names and values
      * @return object          a new DB object. A DB\Error object on failure.
      *
      * @see DB\Driver\Common::setOption()
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public static function factory($type, $options = false)
+    public static function factory($type, array $options = [])
     {
-        if (!is_array($options)) {
-            $options = ['persistent' => $options];
-        }
-
         $classname = self::qualifyClassname($type);
 
         if (!class_exists($classname)) {

--- a/src/DB.php
+++ b/src/DB.php
@@ -198,10 +198,10 @@ class DB
     const DB_FETCHMODE_ASSOC = 2;
 
     // @const Column data as object properties
-    const DB_FETCHMODE_OBJECT = 3;
+    const DB_FETCHMODE_OBJECT = 4;
 
     // @const "flipped" format, where results are an array of columns, not an array of rows
-    const DB_FETCHMODE_FLIPPED = 4;
+    const DB_FETCHMODE_FLIPPED = 8;
 
     /**
      * The type of information to return from the tableInfo() method.

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1171,22 +1171,24 @@ abstract class Common extends Util
      */
     public function getRow($query, $params = [], $fetchmode = DB::DB_FETCHMODE_DEFAULT)
     {
-        // compat check, the params and fetchmode parameters used to
-        // have the opposite order
+        /**
+         * there used to be a backward compatibility thing here that checked
+         * for the possibility of transposed $params and $fetchmode.
+         *
+         * i'm not in any way sorry to say: it's gone. another "nice" feature
+         * to permit you to send a scalar value instead of a single-element
+         * array made this complicated, and in that situation, the parameter
+         * was lost, and absorbed into fetchmode.
+         *
+         * only, this made things complicated. at first it wasn't obvious,
+         * but fetchmode is checked with bitwise ops, so when php 7.1 strict
+         * bitwise came along, and started comparing strings with bit ops, it
+         * broke.
+         */
         if (!is_array($params)) {
-            if (is_array($fetchmode)) {
-                if ($params === null) {
-                    $tmp = DB::DB_FETCHMODE_DEFAULT;
-                } else {
-                    $tmp = $params;
-                }
-                $params = $fetchmode;
-                $fetchmode = $tmp;
-            } elseif ($params !== null) {
-                $fetchmode = $params;
-                $params = [];
-            }
+            $params = [$params];
         }
+
         // modifyLimitQuery() would be nice here, but it causes BC issues
         if (count($params) > 0) {
             $sth = $this->prepare($query);
@@ -1480,21 +1482,10 @@ abstract class Common extends Util
      */
     public function getAll($query, $params = [], $fetchmode = DB::DB_FETCHMODE_DEFAULT)
     {
-        // compat check, the params and fetchmode parameters used to
-        // have the opposite order
+        // see comment at the top of getRow() - transposed $params and
+        // $fetchmode is no longer supported.
         if (!is_array($params)) {
-            if (is_array($fetchmode)) {
-                if ($params === null) {
-                    $tmp = DB::DB_FETCHMODE_DEFAULT;
-                } else {
-                    $tmp = $params;
-                }
-                $params = $fetchmode;
-                $fetchmode = $tmp;
-            } elseif ($params !== null) {
-                $fetchmode = $params;
-                $params = [];
-            }
+            $params = [$params];
         }
 
         if (sizeof($params) > 0) {

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -128,7 +128,6 @@ abstract class Common extends Util
 
     /**
      * Flag indicating that the last query was a manipulation query.
-     * @access protected
      * @var boolean
      */
     protected $lastQueryManip = false;
@@ -136,7 +135,6 @@ abstract class Common extends Util
     /**
      * Flag indicating that the next query <em>must</em> be a manipulation
      * query.
-     * @access protected
      * @var boolean
      */
     protected $nextQueryManip = false;
@@ -155,8 +153,6 @@ abstract class Common extends Util
 
     /**
      * This constructor calls <kbd>parent::__construct('Pineapple\DB\Error')</kbd>
-     *
-     * @return void
      */
     public function __construct()
     {
@@ -1228,7 +1224,7 @@ abstract class Common extends Util
      *                        passed must match quantity of placeholders in
      *                        query:  meaning 1 placeholder for non-array
      *                        parameters or 1 placeholder per array element.
-     * @return array          the results as an array.  A Pineapple\DB\Error object on failure.
+     * @return array          the results as an array. A Pineapple\DB\Error object on failure.
      *
      * @see Common::query()
      *
@@ -1236,7 +1232,7 @@ abstract class Common extends Util
      */
     public function getCol($query, $col = 0, $params = [])
     {
-        $params = (array)$params;
+        $params = (array) $params;
         if (count($params) > 0) {
             $sth = $this->prepare($query);
 
@@ -1292,50 +1288,50 @@ abstract class Common extends Util
      *
      * For example, if the table "mytable" contains:
      *
-     * <pre>
-     *  ID      TEXT       DATE
-     * --------------------------------
-     *  1       'one'      944679408
-     *  2       'two'      944679408
-     *  3       'three'    944679408
-     * </pre>
+     * | ID | TEXT    | DATE      |
+     * |----|---------|-----------|
+     * | 1  | 'one'   | 944679408 |
+     * | 2  | 'two'   | 944679408 |
+     * | 3  | 'three' | 944679408 |
      *
-     * Then the call getAssoc('SELECT id,text FROM mytable') returns:
-     * <pre>
+     * Then the call `getAssoc('SELECT id,text FROM mytable')` returns:
+     * ```php
      *   [
      *     '1' => 'one',
      *     '2' => 'two',
      *     '3' => 'three',
      *   ]
-     * </pre>
+     * ```
      *
-     * ...while the call getAssoc('SELECT id,text,date FROM mytable') returns:
-     * <pre>
+     * ...while the call `getAssoc('SELECT id,text,date FROM mytable')` returns:
+     * ```php
      *   [
      *     '1' => ['one', '944679408'],
      *     '2' => ['two', '944679408'],
      *     '3' => ['three', '944679408']
      *   ]
-     * </pre>
+     * ```
      *
      * If the more than one row occurs with the same value in the
      * first column, the last row overwrites all previous ones by
      * default.  Use the $group parameter if you don't want to
      * overwrite like this.  Example:
      *
-     * <pre>
-     * getAssoc('SELECT category,id,name FROM mytable', false, null,
-     *          DB_FETCHMODE_ASSOC, true) returns:
+     * `getAssoc('SELECT category,id,name FROM mytable', false, null,
+     *          DB_FETCHMODE_ASSOC, true)` returns:
      *
+     * ```php
      *   [
-     *     '1' => [['id' => '4', 'name' => 'number four'],
-     *             ['id' => '6', 'name' => 'number six']
-     *            ],
-     *     '9' => [['id' => '4', 'name' => 'number four'],
-     *             ['id' => '6', 'name' => 'number six']
-     *            ]
+     *     '1' => [
+     *       ['id' => '4', 'name' => 'number four'],
+     *       ['id' => '6', 'name' => 'number six']
+     *     ],
+     *     '9' => [
+     *       ['id' => '4', 'name' => 'number four'],
+     *       ['id' => '6', 'name' => 'number six']
+     *     ]
      *   ]
-     * </pre>
+     * ```
      *
      * Keep in mind that database functions in PHP usually return string
      * values for results regardless of the database's internal type.
@@ -1405,6 +1401,16 @@ abstract class Common extends Util
         if ($cols > 2 || $forceArray) {
             // return array values
             // @todo this part can be optimized
+
+            /**
+             * @todo I'm acutely aware that this is probably a 50-line bug, because:
+             * - there's no bitwise ops (meaning combined bits will fall to else block)
+             * - it's likely combined flip won't work either
+             * - result doesn't handle bitwise either
+             * - the (possibly combined) fetchmode isn't passed into fetchRow()
+             * "fixing" this would possibly introduce bugs in code that depend on the
+             * broken behaviour, so fixing this does _not_ seem like a priority.
+             */
             if ($fetchmode == DB::DB_FETCHMODE_ASSOC) {
                 while (is_array($row = $res->fetchRow(DB::DB_FETCHMODE_ASSOC))) {
                     reset($row);
@@ -1463,20 +1469,19 @@ abstract class Common extends Util
     /**
      * Fetches all of the rows from a query result
      *
-     * @param string $query      the SQL query
-     * @param mixed  $params     array, string or numeric data to be used in
-     *                            execution of the statement.  Quantity of
-     *                            items passed must match quantity of
-     *                            placeholders in query:  meaning 1
-     *                            placeholder for non-array parameters or
-     *                            1 placeholder per array element.
-     * @param int    $fetchmode  the fetch mode to use:
-     *                            + DB_FETCHMODE_ORDERED
-     *                            + DB_FETCHMODE_ASSOC
-     *                            + DB_FETCHMODE_ORDERED | DB_FETCHMODE_FLIPPED
-     *                            + DB_FETCHMODE_ASSOC | DB_FETCHMODE_FLIPPED
-     *
-     * @return array  the nested array.  A Pineapple\DB\Error object on failure.
+     * @param string $query     the SQL query
+     * @param mixed  $params    array, string or numeric data to be used in
+     *                          execution of the statement.  Quantity of
+     *                          items passed must match quantity of
+     *                          placeholders in query:  meaning 1
+     *                          placeholder for non-array parameters or
+     *                          1 placeholder per array element.
+     * @param int    $fetchmode the fetch mode to use:
+     *                          - DB_FETCHMODE_ORDERED
+     *                          - DB_FETCHMODE_ASSOC
+     *                          - DB_FETCHMODE_ORDERED | DB_FETCHMODE_FLIPPED
+     *                          - DB_FETCHMODE_ASSOC | DB_FETCHMODE_FLIPPED
+     * @return array            the nested array. A Pineapple\DB\Error object on failure.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
@@ -1524,10 +1529,9 @@ abstract class Common extends Util
     /**
      * Enables or disables automatic commits
      *
-     * @param bool $onoff  true turns it on, false turns it off
-     *
-     * @return int|Error   DB_OK on success. A Pineapple\DB\Error object if
-     *                     the driver doesn't support auto-committing transactions.
+     * @param bool $onoff true turns it on, false turns it off
+     * @return int|Error  DB_OK on success. A Pineapple\DB\Error object if
+     *                    the driver doesn't support auto-committing transactions.
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -1540,7 +1544,7 @@ abstract class Common extends Util
     /**
      * Commits the current transaction
      *
-     * @return int|Error  DB_OK on success. A Pineapple\DB\Error object on failure.
+     * @return int|Error DB_OK on success. A Pineapple\DB\Error object on failure.
      */
     public function commit()
     {
@@ -1550,7 +1554,7 @@ abstract class Common extends Util
     /**
      * Reverts the current transaction
      *
-     * @return int|Error  DB_OK on success.  A Pineapple\DB\Error object on failure.
+     * @return int|Error DB_OK on success. A Pineapple\DB\Error object on failure.
      */
     public function rollback()
     {
@@ -1560,9 +1564,8 @@ abstract class Common extends Util
     /**
      * Determines the number of rows in a query result
      *
-     * @param resource $result  the query result idenifier produced by PHP
-     *
-     * @return int|Error  the number of rows.  A Pineapple\DB\Error object on failure.
+     * @param StatementContainer $result the query result idenifier produced by PHP
+     * @return int|Error                 the number of rows.  A Pineapple\DB\Error object on failure.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -1588,26 +1591,25 @@ abstract class Common extends Util
      *
      * Basically a wrapper for Pineapple\Util::raiseError without the message string.
      *
-     * @param mixed   integer error code, or a Pineapple\Error object (all
-     *                other parameters are ignored if this parameter is
-     *                an object
-     * @param int     error mode, see Pineapple\Error docs
-     * @param mixed   if error mode is PEAR_ERROR_TRIGGER, this is the
-     *                error level (E_USER_NOTICE etc).  If error mode is
-     *                PEAR_ERROR_CALLBACK, this is the callback function,
-     *                either as a function name, or as an array of an
-     *                object and method name.  For other error modes this
-     *                parameter is ignored.
-     * @param string  extra debug information.  Defaults to the last
-     *                query and native error code.
-     * @param mixed   native error code, integer or string depending the
-     *                backend
-     * @param mixed   dummy parameter for E_STRICT compatibility with
-     *                Pineapple\Util::raiseError
-     * @param mixed   dummy parameter for E_STRICT compatibility with
-     *                Pineapple\Util::raiseError
-     *
-     * @return Error  the Pineapple\Error object
+     * @param mixed  integer error code, or a Pineapple\Error object (all
+     *               other parameters are ignored if this parameter is
+     *               an object
+     * @param int    error mode, see Pineapple\Error docs
+     * @param mixed  if error mode is PEAR_ERROR_TRIGGER, this is the
+     *               error level (E_USER_NOTICE etc).  If error mode is
+     *               PEAR_ERROR_CALLBACK, this is the callback function,
+     *               either as a function name, or as an array of an
+     *               object and method name. For other error modes this
+     *               parameter is ignored.
+     * @param string extra debug information. Defaults to the last
+     *               query and native error code.
+     * @param mixed  native error code, integer or string depending the
+     *               backend
+     * @param mixed  dummy parameter for E_STRICT compatibility with
+     *               Pineapple\Util::raiseError
+     * @param mixed  dummy parameter for E_STRICT compatibility with
+     *               Pineapple\Util::raiseError
+     * @return Error the Pineapple\Error object
      *
      * @see Pineapple\Error
      *
@@ -1656,11 +1658,10 @@ abstract class Common extends Util
     /**
      * Maps native error codes to DB's portable ones
      *
-     * @param string|int $nativecode  the error code returned by the DBMS
-     *
-     * @return int  the portable DB error code.  Return DB_ERROR if the
-     *              current driver doesn't have a mapping for the
-     *              $nativecode submitted.
+     * @param string|int $nativecode the error code returned by the DBMS
+     * @return int                   the portable DB error code.  Return DB_ERROR if the
+     *                               current driver doesn't have a mapping for the
+     *                               $nativecode submitted.
      */
     public function errorCode($nativecode)
     {
@@ -1671,10 +1672,9 @@ abstract class Common extends Util
     /**
      * Maps a DB error code to a textual message
      *
-     * @param integer $dbcode  the DB error code
-     *
-     * @return string  the error message corresponding to the error code
-     *                  submitted.  FALSE if the error code is unknown.
+     * @param int $dbcode the DB error code
+     * @return string     the error message corresponding to the error code
+     *                    submitted.  FALSE if the error code is unknown.
      *
      * @see DB::errorMessage()
      *
@@ -1690,17 +1690,14 @@ abstract class Common extends Util
      *
      * The format of the resulting array depends on which <var>$mode</var>
      * you select.  The sample output below is based on this query:
-     * <pre>
+     * ```sql
      *    SELECT tblFoo.fldID, tblFoo.fldPhone, tblBar.fldId
      *    FROM tblFoo
      *    JOIN tblBar ON tblFoo.fldId = tblBar.fldId
-     * </pre>
+     * ```
      *
-     * <ul>
-     * <li>
-     *
-     * <kbd>null</kbd> (default)
-     *   <pre>
+     * `null` (default)
+     *   ```php
      *   [0] => Array (
      *       [table] => tblFoo
      *       [name] => fldId
@@ -1722,40 +1719,34 @@ abstract class Common extends Util
      *       [len] => 11
      *       [flags] => primary_key not_null
      *   )
-     *   </pre>
+     *   ```
      *
-     * </li><li>
+     * `DB_TABLEINFO_ORDER`
      *
-     * <kbd>DB_TABLEINFO_ORDER</kbd>
+     * In addition to the information found in the default output, a notation
+     * of the number of columns is provided by the `num_fields` element while
+     * the `order` element provides an array with the column names as the keys
+     * and their location index number (corresponding to the keys in the
+     * default output) as the values.
      *
-     *   <p>In addition to the information found in the default output,
-     *   a notation of the number of columns is provided by the
-     *   <samp>num_fields</samp> element while the <samp>order</samp>
-     *   element provides an array with the column names as the keys and
-     *   their location index number (corresponding to the keys in the
-     *   the default output) as the values.</p>
+     * If a result set has identical field names, the last one is used.
      *
-     *   <p>If a result set has identical field names, the last one is
-     *   used.</p>
-     *
-     *   <pre>
+     *   ```php
      *   [num_fields] => 3
      *   [order] => Array (
      *       [fldId] => 2
      *       [fldTrans] => 1
      *   )
-     *   </pre>
+     *   ```
      *
-     * </li><li>
+     * `DB_TABLEINFO_ORDERTABLE`
      *
-     * <kbd>DB_TABLEINFO_ORDERTABLE</kbd>
+     * Similar to `DB_TABLEINFO_ORDER` but adds more dimensions to the array
+     * in which the table names are keys and the field names are sub-keys.
+     * This is helpful for queries that join tables which have identical
+     * field names.
      *
-     *   <p>Similar to <kbd>DB_TABLEINFO_ORDER</kbd> but adds more
-     *   dimensions to the array in which the table names are keys and
-     *   the field names are sub-keys.  This is helpful for queries that
-     *   join tables which have identical field names.</p>
-     *
-     *   <pre>
+     *   ```php
      *   [num_fields] => 3
      *   [ordertable] => Array (
      *       [tblFoo] => Array (
@@ -1766,42 +1757,37 @@ abstract class Common extends Util
      *           [fldId] => 2
      *       )
      *   )
-     *   </pre>
+     *   ```
      *
-     * </li>
-     * </ul>
+     * The `flags` element contains a space separated list of extra
+     * information about the field.  This data is inconsistent between DBMS's
+     * due to the way each DBMS works.
+     *   + `primary_key`
+     *   + `unique_key`
+     *   + `multiple_key`
+     *   + `not_null`
      *
-     * The <samp>flags</samp> element contains a space separated list
-     * of extra information about the field.  This data is inconsistent
-     * between DBMS's due to the way each DBMS works.
-     *   + <samp>primary_key</samp>
-     *   + <samp>unique_key</samp>
-     *   + <samp>multiple_key</samp>
-     *   + <samp>not_null</samp>
-     *
-     * Most DBMS's only provide the <samp>table</samp> and <samp>flags</samp>
-     * elements if <var>$result</var> is a table name.  The following DBMS's
-     * provide full information from queries:
+     * Most DBMS's only provide the `table` and `flags` elements if `$result`
+     * is a table name. The following DBMS's provide full information from
+     * queries:
      *   + fbsql
      *   + mysql
      *
-     * If the 'portability' option has <samp>DB_PORTABILITY_LOWERCASE</samp>
-     * turned on, the names of tables and fields will be lowercased.
+     * If the 'portability' option has `DB_PORTABILITY_LOWERCASE` turned on,
+     * the names of tables and fields will be lowercased.
      *
      * @param object|string  $result  Result object from a query or a
      *                                string containing the name of a table.
      *                                While this also accepts a query result
      *                                resource identifier, this behavior is
      *                                deprecated.
-     * @param int  $mode   either unused or one of the tableInfo modes:
-     *                     <kbd>DB_TABLEINFO_ORDERTABLE</kbd>,
-     *                     <kbd>DB_TABLEINFO_ORDER</kbd> or
-     *                     <kbd>DB_TABLEINFO_FULL</kbd> (which does both).
-     *                     These are bitwise, so the first two can be
-     *                     combined using <kbd>|</kbd>.
-     *
-     * @return array|Error  an associative array with the information requested.
-     *                      A Pineapple\DB\Error object on failure.
+     * @param int  $mode              either unused or one of the tableInfo modes:
+     *                                `DB_TABLEINFO_ORDERTABLE`,
+     *                                `DB_TABLEINFO_ORDER` or `DB_TABLEINFO_FULL`
+     *                                (which does both). These are bitwise, so the
+     *                                first two can be combined using `|`.
+     * @return array|Error            an associative array with the information requested.
+     *                                A Pineapple\DB\Error object on failure.
      *
      * @see Common::setOption()
      *
@@ -1810,7 +1796,7 @@ abstract class Common extends Util
     public function tableInfo($result, $mode = null)
     {
         /**
-         * If the DB_<driver> class has a tableInfo() method, that one
+         * If the driver class has a tableInfo() method, that one
          * overrides this one.  But, if the driver doesn't have one,
          * this method runs and tells users about that fact.
          */
@@ -1821,12 +1807,8 @@ abstract class Common extends Util
      * Sets (or unsets) a flag indicating that the next query will be a
      * manipulation query, regardless of the usual self::isManip() heuristics.
      *
-     * @param boolean true to set the flag overriding the isManip() behaviour,
-     * false to clear it and fall back onto isManip()
-     *
-     * @return void
-     *
-     * @access public
+     * @param boolean $manip true to set the flag overriding the isManip() behaviour,
+     *                       false to clear it and fall back onto isManip()
      */
     public function nextQueryIsManip($manip)
     {
@@ -1840,9 +1822,8 @@ abstract class Common extends Util
      * Examples of data definition queries are CREATE, DROP, ALTER, GRANT,
      * REVOKE.
      *
-     * @param string $query  the query
-     *
-     * @return boolean  whether $query is a data manipulation query
+     * @param string $query the query
+     * @return boolean      whether $query is a data manipulation query
      */
     public static function isManip($query)
     {
@@ -1873,12 +1854,9 @@ abstract class Common extends Util
      * account the nextQueryManip flag and sets the lastQueryManip flag
      * (and resets nextQueryManip) according to the result.
      *
-     * @param string The query to check.
-     *
+     * @param string   The query to check.
      * @return boolean true if the query is a manipulation query, false
-     * otherwise
-     *
-     * @access protected
+     *                 otherwise
      */
     protected function checkManip($query)
     {
@@ -1891,10 +1869,6 @@ abstract class Common extends Util
      * Right-trims all strings in an array
      *
      * @param array $array  the array to be trimmed (passed by reference)
-     *
-     * @return void
-     *
-     * @access protected
      */
     protected function rtrimArrayValues(&$array)
     {
@@ -1909,10 +1883,6 @@ abstract class Common extends Util
      * Converts all null values in an array to empty strings
      *
      * @param array  $array  the array to be de-nullified (passed by reference)
-     *
-     * @return void
-     *
-     * @access protected
      */
     protected function convertNullArrayValuesToEmpty(&$array)
     {

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1055,7 +1055,7 @@ abstract class Common extends Util
      */
     public function query($query, $params = [])
     {
-        if (sizeof($params) > 0) {
+        if (count($params) > 0) {
             $sth = $this->prepare($query);
             if (DB::isError($sth)) {
                 return $sth;
@@ -1127,7 +1127,7 @@ abstract class Common extends Util
         $row = null;
         $params = (array)$params;
         // modifyLimitQuery() would be nice here, but it causes BC issues
-        if (sizeof($params) > 0) {
+        if (count($params) > 0) {
             $sth = $this->prepare($query);
             if (DB::isError($sth)) {
                 return $sth;
@@ -1237,7 +1237,7 @@ abstract class Common extends Util
     public function getCol($query, $col = 0, $params = [])
     {
         $params = (array)$params;
-        if (sizeof($params) > 0) {
+        if (count($params) > 0) {
             $sth = $this->prepare($query);
 
             if (DB::isError($sth)) {
@@ -1374,7 +1374,7 @@ abstract class Common extends Util
     ) {
         $row = null;
         $params = (array) $params;
-        if (sizeof($params) > 0) {
+        if (count($params) > 0) {
             $sth = $this->prepare($query);
 
             if (DB::isError($sth)) {
@@ -1488,7 +1488,7 @@ abstract class Common extends Util
             $params = [$params];
         }
 
-        if (sizeof($params) > 0) {
+        if (count($params) > 0) {
             $sth = $this->prepare($query);
 
             if (DB::isError($sth)) {

--- a/src/DB/Driver/Components/AnsiSqlErrorCodes.php
+++ b/src/DB/Driver/Components/AnsiSqlErrorCodes.php
@@ -3,6 +3,14 @@ namespace Pineapple\DB\Driver\Components;
 
 use Pineapple\DB;
 
+/**
+ * ANSI SQL error codes, taken from the PHP PDO source code.
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @license    BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
+ */
 trait AnsiSqlErrorCodes
 {
     /**
@@ -65,7 +73,6 @@ trait AnsiSqlErrorCodes
      * returning a standard 'generic error' if unmappable.
      *
      * @param string $code The driver error code to map to native
-     *
      * @return int         The DB::DB_ERROR_* constant
      */
     public function getNativeErrorCode($code)

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -220,8 +220,6 @@ trait PdoCommonMethods
      *                        parameters or 1 placeholder per array element.
      * @return string         the query string with LIMIT clauses added
      *
-     * @access protected
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function modifyLimitQuery($query, $from, $count, $params = [])

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -4,12 +4,20 @@ namespace Pineapple\DB\Driver\Components;
 use Pineapple\DB;
 use Pineapple\DB\StatementContainer;
 
+/**
+ * Common methods shared amongst PDO and PDO-alike drivers.
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @license    BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
+ */
 trait PdoCommonMethods
 {
     /**
      * Disconnects from the database server
      *
-     * @return bool  TRUE on success, FALSE on failure
+     * @return bool     true on success, false on failure
      */
     public function disconnect()
     {
@@ -22,8 +30,7 @@ trait PdoCommonMethods
      *
      * This method has not been implemented yet.
      *
-     * @return false
-     * @access public
+     * @return bool     will always be false
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -39,9 +46,8 @@ trait PdoCommonMethods
      * Pineapple\DB\Result::free() instead.  It can't be declared "protected"
      * because Pineapple\DB\Result is a separate object.
      *
-     * @param PDOStatement $result PHP's query result resource
-     *
-     * @return bool                TRUE on success, FALSE if $result is invalid
+     * @param StatementContainer $result PHP query statement handle
+     * @return bool                      true on success, false if $result is invalid
      *
      * @see Pineapple\DB\Result::free()
      */
@@ -59,10 +65,9 @@ trait PdoCommonMethods
      * Pineapple\DB\Result::numCols() instead.  It can't be declared
      * "protected" because Pineapple\DB\Result is a separate object.
      *
-     * @param resource $result  PHP's query result resource
-     *
-     * @return int|Error        the number of columns. A Pineapple\DB\Error
-     *                          object on failure.
+     * @param StatementContainer $result PHP query statement handle
+     * @return int|Error                 the number of columns. A Pineapple\DB\Error
+     *                                   object on failure.
      *
      * @see Pineapple\DB\Result::numCols()
      */
@@ -82,10 +87,9 @@ trait PdoCommonMethods
      * Pineapple\DB\Result::numRows() instead.  It can't be declared "protected"
      * because Pineapple\DB\Result is a separate object.
      *
-     * @param resource $result  PHP's query result resource
-     *
-     * @return int|Error        the number of rows. A Pineapple\DB\Error
-     *                          object on failure.
+     * @param StatementContainer $result PHP query statement handle
+     * @return int|Error                 the number of rows. A Pineapple\DB\Error
+     *                                   object on failure.
      *
      * @see Pineapple\DB\Result::numRows()
      * @todo This is not easily testable, since not all drivers support this for SELECTs
@@ -104,7 +108,6 @@ trait PdoCommonMethods
      * Enables or disables automatic commits
      *
      * @param bool $onoff  true turns it on, false turns it off
-     *
      * @return int|Error   DB_OK on success. A Pineapple\DB\Error object if
      *                     the driver doesn't support auto-committing
      *                     transactions.
@@ -128,7 +131,6 @@ trait PdoCommonMethods
      * character (<kbd>`</kbd>) in table or column names.
      *
      * @param string $str  identifier name to be quoted
-     *
      * @return string      quoted identifier string
      *
      * @see Pineapple\DB\Driver\Common::quoteIdentifier()
@@ -143,7 +145,6 @@ trait PdoCommonMethods
      * Escapes a string according to the current DBMS's standards
      *
      * @param string $str   the string to be escaped
-     *
      * @return string|Error the escaped string, or an error
      *
      * @see Pineapple\DB\Driver\Common::quoteSmart()
@@ -217,8 +218,7 @@ trait PdoCommonMethods
      *                        passed must match quantity of placeholders in
      *                        query:  meaning 1 placeholder for non-array
      *                        parameters or 1 placeholder per array element.
-     *
-     * @return string  the query string with LIMIT clauses added
+     * @return string         the query string with LIMIT clauses added
      *
      * @access protected
      *
@@ -232,9 +232,9 @@ trait PdoCommonMethods
             // @codeCoverageIgnoreStart
             return $query . " LIMIT $count";
             // @codeCoverageIgnoreEnd
-        } else {
-            return $query . " LIMIT $from, $count";
         }
+
+        return $query . " LIMIT $from, $count";
     }
 
     /**
@@ -243,19 +243,17 @@ trait PdoCommonMethods
      * @param int $errno  if the error is being manually raised pass a
      *                    DB_ERROR* constant here.  If this isn't passed
      *                    the error information gathered from the DBMS.
-     *
-     * @return object  the Pineapple\DB\Error object
+     * @return object     the Pineapple\DB\Error object
      *
      * @see Pineapple\DB\Driver\Common::raiseError(),
      *      Pineapple\DB\Driver\DoctrineDbal::errorNative(), Pineapple\DB\Driver\Common::errorCode()
      */
     private function myRaiseError($errno = null)
     {
-        if ($this->connected()) {
-            $error = $this->connection->errorInfo();
-        } else {
-            $error = ['Disconnected', null, 'No active connection'];
-        }
+        $error = $this->connected() ?
+            $this->connection->errorInfo() :
+            ['Disconnected', null, 'No active connection'];
+
         return $this->raiseError(
             $errno,
             null,
@@ -299,13 +297,12 @@ trait PdoCommonMethods
     /**
      * Returns information about a table or a result set
      *
-     * @param PDOStatement|string $result Pineapple\DB\Result object from a query or a
-     *                                    string containing the name of a table.
-     *                                    While this also accepts a query result
-     *                                    resource identifier, this behavior is
-     *                                    deprecated.
-     * @param int                 $mode   a valid tableInfo mode
-     *
+     * @param StatementContainer|string $result Pineapple\DB\Result object from a query or a
+     *                                          string containing the name of a table.
+     *                                          While this also accepts a query result
+     *                                          resource identifier, this behavior is
+     *                                          deprecated.
+     * @param int                       $mode   a valid tableInfo mode
      * @return mixed   an associative array with the information requested.
      *                 A Pineapple\DB\Error object on failure.
      *
@@ -345,11 +342,9 @@ trait PdoCommonMethods
 
         $tableHandle = self::getStatement($tableHandle);
 
-        if ($this->options['portability'] & DB::DB_PORTABILITY_LOWERCASE) {
-            $caseFunc = 'strtolower';
-        } else {
-            $caseFunc = 'strval';
-        }
+        $caseFunc = ($this->options['portability'] & DB::DB_PORTABILITY_LOWERCASE) ?
+            'strtolower' :
+            'strval';
 
         $count = $tableHandle->columnCount();
         $res = [];

--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -55,7 +55,6 @@ class DoctrineDbal extends Common implements DriverInterface
     /**
      * Should data manipulation queries be committed automatically?
      * @var bool
-     * @access protected
      */
     protected $autocommit = true;
 
@@ -63,7 +62,6 @@ class DoctrineDbal extends Common implements DriverInterface
      * The quantity of transactions begun
      *
      * @var integer
-     * @access private
      */
     private $transactionOpcount = 0;
 

--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -20,6 +20,11 @@ use PDOException;
 /**
  * A PEAR DB driver that uses Doctrine's DBAL as an underlying database
  * layer.
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @copyright  BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.1.0
  */
 class DoctrineDbal extends Common implements DriverInterface
 {

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -38,7 +38,6 @@ interface DriverInterface
      *
      * @param mixed $result a valid sql result resource/object
      * @return false
-     * @access public
      */
     public function nextResult(StatementContainer $result);
 

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -49,7 +49,6 @@ class PdoDriver extends Common implements DriverInterface
     /**
      * Should data manipulation queries be committed automatically?
      * @var bool
-     * @access protected
      */
     protected $autocommit = true;
 
@@ -57,7 +56,6 @@ class PdoDriver extends Common implements DriverInterface
      * The quantity of transactions begun
      *
      * @var integer
-     * @access private
      */
     private $transactionOpcount = 0;
 

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -14,6 +14,11 @@ use PDOException;
 
 /**
  * A PEAR DB driver that uses PDO as an underlying database layer.
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @copyright  BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
  */
 class PdoDriver extends Common implements DriverInterface
 {

--- a/src/DB/Exception/DriverException.php
+++ b/src/DB/Exception/DriverException.php
@@ -3,6 +3,14 @@ namespace Pineapple\DB\Exception;
 
 use Exception;
 
+/**
+ * Exceptions which occur in the Pineapple Driver layer
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @license    BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
+ */
 class DriverException extends Exception
 {
 }

--- a/src/DB/Exception/FeatureException.php
+++ b/src/DB/Exception/FeatureException.php
@@ -3,6 +3,14 @@ namespace Pineapple\DB\Exception;
 
 use Exception;
 
+/**
+ * Exceptions which occur due to driver features
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @license    BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
+ */
 class FeatureException extends Exception
 {
 }

--- a/src/DB/Exception/StatementException.php
+++ b/src/DB/Exception/StatementException.php
@@ -3,6 +3,14 @@ namespace Pineapple\DB\Exception;
 
 use Exception;
 
+/**
+ * Exceptions which within the StatementContainer class
+ *
+ * @author     Rob Andrews <rob@aphlor.org>
+ * @license    BSD-2-Clause
+ * @package    Database
+ * @version    Introduced in Pineapple 0.3.0
+ */
 class StatementException extends Exception
 {
     const NO_STATEMENT = -128;

--- a/src/DB/Row.php
+++ b/src/DB/Row.php
@@ -24,8 +24,6 @@ class Row
      * The constructor places a row's data into properties of this object
      *
      * @param array  the array containing the row's data
-     *
-     * @return void
      */
     public function __construct(&$arr)
     {

--- a/src/DB/StatementContainer.php
+++ b/src/DB/StatementContainer.php
@@ -67,7 +67,10 @@ class StatementContainer
                     'We do not know how to deal with this type of statement handle',
                     StatementException::UNHANDLED_TYPE
                 );
+                // unreachable.
+                // @codeCoverageIgnoreStart
                 break;
+                // @codeCoverageIgnoreEnd
         }
 
         $this->statement = $statement;

--- a/src/Error.php
+++ b/src/Error.php
@@ -32,18 +32,15 @@ class Error
     /**
      * Pineapple\Error constructor
      *
-     * @param string $message message
-     * @param int    $code    (optional) error code
-     * @param int    $mode    (optional) error mode, one of: PEAR_ERROR_RETURN,
-     *                        PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
-     *                        PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
-     * @param mixed  $options (optional) error level, _OR_ in the case of
-     *                        PEAR_ERROR_CALLBACK, the callback function or object/method
-     *                        tuple.
-     *
+     * @param string $message  message
+     * @param int    $code     (optional) error code
+     * @param int    $mode     (optional) error mode, one of: PEAR_ERROR_RETURN,
+     *                         PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
+     *                         PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
+     * @param mixed  $options  (optional) error level, _OR_ in the case of
+     *                         PEAR_ERROR_CALLBACK, the callback function or object/method
+     *                         tuple.
      * @param string $userInfo (optional) additional user/debug info
-     *
-     * @access public
      */
     public function __construct($message = null, $code = null, $mode = null, $options = null, $userInfo = null)
     {
@@ -119,7 +116,6 @@ class Error
      * Get the error mode from an error object.
      *
      * @return int error mode
-     * @access public
      */
     public function getMode()
     {
@@ -130,7 +126,6 @@ class Error
      * Get the callback function/method from an error object.
      *
      * @return mixed callback function or object/method array
-     * @access public
      */
     public function getCallback()
     {
@@ -141,7 +136,6 @@ class Error
      * Get the error message from an error object.
      *
      * @return  string  full error message
-     * @access public
      */
     public function getMessage()
     {
@@ -152,7 +146,6 @@ class Error
      * Get error code from an error object
      *
      * @return int error code
-     * @access public
      */
     public function getCode()
     {
@@ -163,7 +156,6 @@ class Error
      * Get the name of this error/exception.
      *
      * @return string error/exception name (type)
-     * @access public
      */
     public function getType()
     {
@@ -174,7 +166,6 @@ class Error
      * Get additional user-supplied information.
      *
      * @return string user-supplied information
-     * @access public
      */
     public function getUserInfo()
     {
@@ -185,7 +176,6 @@ class Error
      * Get additional debug information supplied by the application.
      *
      * @return string debug information
-     * @access public
      */
     public function getDebugInfo()
     {
@@ -197,8 +187,7 @@ class Error
      * Supported with PHP 4.3.0 or newer.
      *
      * @param int $frame (optional) what frame to fetch
-     * @return array Backtrace, or NULL if not available.
-     * @access public
+     * @return array     Backtrace, or NULL if not available.
      */
     public function getBacktrace($frame = null)
     {
@@ -226,7 +215,6 @@ class Error
      * Make a string representation of this object.
      *
      * @return string a string with an object summary
-     * @access public
      */
     public function toString()
     {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -57,7 +57,7 @@ namespace Pineapple;
  *
  * 5) Usage example
  *
- * <code>
+ * ```php
  *  require_once 'PEAR/Exception.php';
  *
  *  class Test {
@@ -78,7 +78,7 @@ namespace Pineapple;
  *  } catch (PEAR_Exception $e) {
  *     print $e;
  *  }
- * </code>
+ * ```
  *
  * @category   pear
  * @package    PEAR
@@ -112,6 +112,7 @@ class Exception extends \Exception
      *  - Pineapple\Exception(string $message, Error $cause, int $code);
      *  - Pineapple\Exception(string $message, array $causes);
      *  - Pineapple\Exception(string $message, array $causes, int $code);
+     *
      * @param string exception message
      * @param int|\Exception|Error|array|null exception cause
      * @param int|null exception code or null
@@ -139,6 +140,7 @@ class Exception extends \Exception
             $code = null;
             $this->cause = null;
         }
+
         parent::__construct($message, $code);
         $this->signal();
     }
@@ -157,7 +159,7 @@ class Exception extends \Exception
     }
 
     /**
-     * @param  string $label The name of the observer to remove.
+     * @param string $label The name of the observer to remove.
      */
     public static function removeObserver($label = 'default')
     {
@@ -197,7 +199,7 @@ class Exception extends \Exception
                 // @codeCoverageIgnoreStart
                 // can't cover this, die is kind of a finality
                 case self::OBSERVER_DIE:
-                    $f = (isset($func[1])) ? $func[1] : '%s';
+                    $f = isset($func[1]) ? $func[1] : '%s';
                     die(printf($f, $this->getMessage()));
                     break;
                 // @codeCoverageIgnoreEnd
@@ -217,9 +219,10 @@ class Exception extends \Exception
      * to define API
      *
      * The returned array must be an associative array of parameter => value like so:
-     * <pre>
+     * ```php
      * array('name' => $name, 'context' => array(...))
-     * </pre>
+     * ```
+     *
      * @return array
      */
     public function getErrorData()
@@ -229,7 +232,7 @@ class Exception extends \Exception
 
     /**
      * Returns the exception that caused this exception to be thrown
-     * @access public
+     *
      * @return Exception|array The context of the exception
      */
     public function getCause()

--- a/src/Util.php
+++ b/src/Util.php
@@ -66,7 +66,6 @@ class Util
      * Which class to use for error objects.
      *
      * @var     string
-     * @access  protected
      */
     protected $errorClass = Error::class;
 
@@ -75,8 +74,6 @@ class Util
      *
      * @param string $errorClass  (optional) which class to use for
      *                            error objects, defaults to Pineapple\Error.
-     * @access public
-     * @return void
      */
     public function __construct($errorClass = null)
     {
@@ -134,13 +131,12 @@ class Util
     /**
      * Tell whether a value is a Pineapple\Error.
      *
-     * @param   mixed $data   the value to test
-     * @param   int   $code   if $data is an error object, return true
-     *                        only if $code is a string and
-     *                        $obj->getMessage() == $code or
-     *                        $code is an integer and $obj->getCode() == $code
-     *
-     * @return  bool    true if parameter is an error
+     * @param  mixed $data the value to test
+     * @param  int   $code if $data is an error object, return true
+     *                     only if $code is a string and
+     *                     $obj->getMessage() == $code or
+     *                     $code is an integer and $obj->getCode() == $code
+     * @return boolean     true if parameter is an error
      */
     public static function staticIsError($data, $code = null)
     {
@@ -163,34 +159,26 @@ class Util
      * handling applied.  If the $mode and $options parameters are not
      * specified, the object's defaults are used.
      *
-     * @param mixed $message a text error message or a Pineapple\Error object
-     *
-     * @param int $code      a numeric error code (it is up to your class
-     *                       to define these if you want to use codes)
-     *
-     * @param int $mode      One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
-     *                       PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
-     *                       PEAR_ERROR_CALLBACK, PEAR_ERROR_EXCEPTION.
-     *
-     * @param mixed $options If $mode is PEAR_ERROR_TRIGGER, this parameter
-     *                       specifies the PHP-internal error level (one of
-     *                       E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
-     *                       If $mode is PEAR_ERROR_CALLBACK, this
-     *                       parameter specifies the callback function or
-     *                       method.  In other error modes this parameter
-     *                       is ignored.
-     *
-     * @param string $userInfo If you need to pass along for example debug
-     *                         information, this parameter is meant for that.
-     *
+     * @param mixed $message     a text error message or a Pineapple\Error object
+     * @param int $code          a numeric error code (it is up to your class
+     *                           to define these if you want to use codes)
+     * @param int $mode          One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
+     *                           PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
+     *                           PEAR_ERROR_CALLBACK, PEAR_ERROR_EXCEPTION.
+     * @param mixed $options     If $mode is PEAR_ERROR_TRIGGER, this parameter
+     *                           specifies the PHP-internal error level (one of
+     *                           E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
+     *                           If $mode is PEAR_ERROR_CALLBACK, this
+     *                           parameter specifies the callback function or
+     *                           method.  In other error modes this parameter
+     *                           is ignored.
+     * @param string $userInfo   If you need to pass along for example debug
+     *                           information, this parameter is meant for that.
      * @param string $errorClass The returned error object will be
      *                           instantiated from this class, if specified.
-     *
-     * @param bool $skipMessage If true, raiseError will only pass error codes,
-     *                          the error message parameter will be dropped.
-     *
-     * @return object   a Pineapple\Error object
-     * @since PHP 4.0.5
+     * @param bool $skipMessage  If true, raiseError will only pass error codes,
+     *                           the error message parameter will be dropped.
+     * @return object            a Pineapple\Error object
      */
     protected static function staticRaiseError(
         $object,
@@ -219,38 +207,30 @@ class Util
             $ec = Error::class;
         }
 
-        if ($skipMessage) {
-            $a = new $ec($code, self::PEAR_ERROR_RETURN, $options, $userInfo);
-        } else {
-            $a = new $ec($message, $code, self::PEAR_ERROR_RETURN, $options, $userInfo);
-        }
-
-        return $a;
+        return $skipMessage ?
+            new $ec($code, self::PEAR_ERROR_RETURN, $options, $userInfo) :
+            new $ec($message, $code, self::PEAR_ERROR_RETURN, $options, $userInfo);
     }
 
     /**
      * Simpler form of raiseError with fewer options.  In most cases
      * message, code and userInfo are enough.
      *
-     * @param mixed $message a text error message or a Pineapple\Error object
-     *
-     * @param int $code      a numeric error code (it is up to your class
-     *                       to define these if you want to use codes)
-     *
+     * @param mixed $message   a text error message or a Pineapple\Error object
+     * @param int $code        a numeric error code (it is up to your class
+     *                         to define these if you want to use codes)
      * @param string $userInfo If you need to pass along for example debug
      *                         information, this parameter is meant for that.
+     * @return object          a Pineapple\Error object
      *
-     * @return object   a Pineapple\Error object
      * @see Pineapple\Util::raiseError
      */
     protected static function staticThrowError($object, $message = null, $code = null, $userInfo = null)
     {
         if ($object !== null) {
-            $a = $object->raiseError($message, $code, null, null, $userInfo);
-            return $a;
+            return $object->raiseError($message, $code, null, null, $userInfo);
         }
 
-        $a = self::raiseError($message, $code, null, null, $userInfo);
-        return $a;
+        return self::raiseError($message, $code, null, null, $userInfo);
     }
 }

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -1052,6 +1052,38 @@ class CommonTest extends TestCase
         ], $result);
     }
 
+    public function testGetAllAssocTransposed()
+    {
+        $dbh = DB::factory(TestDriver::class);
+
+        $result = $dbh->getAll('SELECT foo FROM bar', [], DB::DB_FETCHMODE_ASSOC | DB::DB_FETCHMODE_FLIPPED);
+        $this->assertEquals([
+            'id' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            'data' => [
+                'test1',
+                'test2',
+                'test3',
+                'test4',
+                'test5',
+                'test6',
+                'test7',
+                'test8',
+                'test9',
+                'test10',
+                'test11',
+                'test12',
+                'test13',
+                'test14',
+                'test15',
+                'test16',
+                'test17',
+                'test18',
+                'test19',
+                'test20',
+            ],
+        ], $result);
+    }
+
     public function testAutoCommit()
     {
         // this is a stub method intended to fail

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -659,19 +659,6 @@ class CommonTest extends TestCase
         $this->assertEquals([1, 'test1'], $result);
     }
 
-    public function testGetRowWithWackyParametersAndAFetchMode()
-    {
-        $dbh = DB::factory(TestDriver::class);
-
-        // if my eyes aren't deceiving me, it appears that the first decision tree in getRow allows you
-        // to transpose the params and fetchmode parameters. to what end i'm not sure.
-        $result = $dbh->getRow('SELECT foo FROM bar WHERE foo = ?', DB::DB_FETCHMODE_ASSOC, ['bar']);
-        $this->assertEquals([
-            'id' => 1,
-            'data' => 'test1',
-        ], $result);
-    }
-
     public function testGetRowWithParametersAndSyntaxError()
     {
         $dbh = DB::factory(TestDriver::class);
@@ -1012,14 +999,6 @@ class CommonTest extends TestCase
         $dbh = DB::factory(TestDriver::class);
 
         $result = $dbh->getAll('SELECT foo FROM bar WHERE foo = ?', null, ['bar']);
-        $this->assertEquals(self::$orderedAllData, $result);
-    }
-
-    public function testGetAllWithScalarParamsAndModeTransposed()
-    {
-        $dbh = DB::factory(TestDriver::class);
-
-        $result = $dbh->getAll('SELECT foo FROM bar WHERE foo = ?', DB::DB_FETCHMODE_ORDERED, ['bar']);
         $this->assertEquals(self::$orderedAllData, $result);
     }
 

--- a/test/DBTest.php
+++ b/test/DBTest.php
@@ -13,7 +13,6 @@ class DBTest extends TestCase
     {
         $dbh = DB::factory(TestDriver::class);
         $this->assertInstanceOf(TestDriver::class, $dbh);
-        $this->assertFalse($dbh->getOption('persistent'));
     }
 
     public function testFactoryWithArrayOptions()
@@ -21,13 +20,6 @@ class DBTest extends TestCase
         $dbh = DB::factory(TestDriver::class, ['debug' => 'q who?']);
         $this->assertInstanceOf(TestDriver::class, $dbh);
         $this->assertEquals('q who?', $dbh->getOption('debug'));
-    }
-
-    public function testFactoryWithLegacyOption()
-    {
-        $dbh = DB::factory(TestDriver::class, true);
-        $this->assertInstanceOf(TestDriver::class, $dbh);
-        $this->assertTrue($dbh->getOption('persistent'));
     }
 
     public function testFactoryWithBadDriver()


### PR DESCRIPTION
This is the second release candidate for 0.3.0.

Changes are:
- We're good to go with PHP 7.1
  + Some unusual behaviour regarding bitwise operations was discovered, due to a backward compatibility feature which attempted to discover transposed parameters. PHP 7.1 raises a warning for this behaviour. This has been fixed, so no warnings, all tests running happily.
- `DB_FETCHMODE_*` constants changed to bit values.
  + There is discrepant behaviour across several classes in which some use bitwise checks and most don't. One class in particular checks for combined fetch modes, which is permitted. Bit values fixes this, though the rest of the classes that _don't_ use bitwise checks probably can't be fixed for fear of dredging up the _intended_ behaviour, and several bugs with it. It's safe as it is, let's just leave it.
- The docblocks now properly reflect the correct input class types. xml markers have been replaced with Github-flavoured markdown.
- Backward compatibility check for transposed `$fetchmode` and `$params` has been removed from `getRow()` and `getAll()`. It kept on putting the parameter into `$fetchmode` when a single, scalar parameter was passed instead of a single value in an array. This isn't going to be put into pineapple-compat, so it's probably best to say goodbye now.
