### PR TITLE
Version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,47 +6,21 @@
 |----------|-------------|
 | [![Build Status](https://travis-ci.org/wethersherbs/pineapple.svg?branch=master)](https://travis-ci.org/wethersherbs/pineapple) | [![Build Status](https://travis-ci.org/wethersherbs/pineapple.svg?branch=dev-0.3.x)](https://travis-ci.org/wethersherbs/pineapple) |
 
+## What?
+
+A compatibility layer around [PDO](http://php.net/pdo) or [Doctrine DBAL](https://github.com/doctrine/dbal) to provide backward compatibility to [PEAR DB](https://github.com/pear/DB)-based applications.
+
 ## Why?
 
 PEAR DB is very old (the copyright range ends 9 years prior to Pineapple's inception), and was obsoleted by MDB2, which has in turn become obsolete. People have code based on these modules, but need an upgrade path that means new code can be developed using modern DB access methods, whilst retaining access for legacy code without opening a second database connection.
 
-This package is a fork of PEAR and DB, heavily refactored. The purpose of it is to provide a method-compatible drop-in replacement, reproducing `PEAR::raiseError` and `PEAR::isError`, and all methods under the `DB` class. Connection-specific drivers are dropped and only two connection drivers are included: `DoctrineDbal`, a driver which takes a constructed [doctrine/dbal](https://github.com/doctrine/dbal) object, and `PdoDriver`, a driver which takes a constructed [PDO](http://php.net/PDO) object. It is intended _only_ as a path to Doctrine DBAL/PDO migration, to keep legacy systems working whilst retaining a single database connection per application.
+## How?
 
-The intention is to strip unused methods, clean (remove all warnings and notices), make PSR-2 clean and provide full test coverage of the DB compatibility layer. Global constants will be replaced with class constants, though the compatibility module ([wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat)) will provide global constants that map to class constants for backward compatibility.
+This package is a fork of PEAR and DB, heavily refactored. The purpose of it is to provide a method-compatible drop-in replacement, reproducing `PEAR::raiseError` and `PEAR::isError`, and all methods under the `DB` class. Connection-specific drivers are dropped and only two connection drivers are included: `DoctrineDbal`, a driver which takes a constructed [doctrine/dbal](https://github.com/doctrine/dbal) object, and `PdoDriver`, a driver which takes a constructed [PDO](http://php.net/PDO) object. It is intended _only_ as a path to PDO or Doctrine DBAL migration, to keep legacy systems working whilst retaining a single database connection per application.
+
+The intention is to strip unused methods, clean (remove all warnings and notices), make PSR-2 clean and provide full test coverage of the DB compatibility layer. Global constants will be replaced with class constants to maintain a clean constant namespace, though the compatibility module ([wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat)) will provide global constants that map to class constants for backward compatibility.
 
 It is up to your application to cache the constructed database connection object. Please do not use Pineapple to retrieve your connection object after it has been dependency injected.
-
-## How does it work?
-
-In order to facilitate a deep rework without breaking compatibility with applications that use the `DB` and `DB_*` classnames, the code has been refactored to reside within the `Pineapple` namespace. Here is a handy table of the mapping:
-
-| Old class        | New class                    |
-|------------------|------------------------------|
-| `DB`             | `Pineapple\DB`               |
-| `DB_Error`       | `Pineapple\DB\Error`         |
-| `DB_result`      | `Pineapple\DB\Result`        |
-| `DB_row`         | `Pineapple\DB\Row`           |
-| `DB_common`      | `Pineapple\DB\Driver\Common` |
-| `PEAR`           | `Pineapple\Util`             |
-| `PEAR_Error`     | `Pineapple\Error`            |
-| `PEAR_Exception` | `Pineapple\Exception`        |
-
-If possible, it would be beneficial for you to refactor your code to use the new class names and class constants (instead of global constants). However, if refactoring isn't an option, you can use the counterpart module, which provides root namespace class names in the left column of the above table. See [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat) and load that into your composer configuration to add compatible classes.
-
-## What's changed? What's missing?
-
-- All classes are namespaced. See the table in the previous section for the class name mappings.
-- All global variables have now been dropped. This also applies to [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat). They will not be retained or readded.
-- Global constants have been moved to class constants. [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat) adds global mappings back to class constants if you're using it as a drop-in replacement.
-- **All connectivity drivers have been removed**. The only drivers provided are `DoctrineDbal` and `PdoDriver` to connect with Doctrine's DBAL and PDO respectively.
-- All methods in PEAR have been dropped, except for `isError`, `raiseError` and `throwError`. This includes PEAR's pseudo-destructors.
-- Compatibility names for legacy constructors and '`_Name`' destructors has been removed and placed in [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat).
-- PEAR & DB Error suppression has been removed.
-- Large swathes of code put in place to aid multi-driver compatibility have been removed.
-- Methods marked deprecated have been moved to [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat). Try not to use them. Some methods have been removed entirely.
-- Spit, polish & PSR-2. Refactoring to support some more modern aspects of PHP (e.g. method statics replaced with class statics).
-
-It would not take a large amount of effort to refactor your code to avoid using the compatibility layer, but it is provided for your convenience.
 
 ## Usage
 
@@ -77,6 +51,40 @@ $db = DB::factory(PdoDriver::class);
 $db->setConnectionHandle(new PDO('sqlite::memory:'));
 $result = $db->query('SELECT CURRENT_TIMESTAMP');
 ```
+
+## What's changed? What's missing?
+
+In order to facilitate a deep rework without breaking compatibility with applications that use the `DB` and `DB_*` classnames, the code has been refactored to reside within the `Pineapple` namespace. Here is a handy table of the mapping:
+
+| Old class        | New class                    |
+|------------------|------------------------------|
+| `DB`             | `Pineapple\DB`               |
+| `DB_Error`       | `Pineapple\DB\Error`         |
+| `DB_result`      | `Pineapple\DB\Result`        |
+| `DB_row`         | `Pineapple\DB\Row`           |
+| `DB_common`      | `Pineapple\DB\Driver\Common` |
+| `PEAR`           | `Pineapple\Util`             |
+| `PEAR_Error`     | `Pineapple\Error`            |
+| `PEAR_Exception` | `Pineapple\Exception`        |
+
+If possible, it would be beneficial for you to refactor your code to use the new class names and class constants (instead of global constants). However, if refactoring isn't an option, you can use the counterpart module, which provides root namespace class names in the left column of the above table. See [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat) and load that into your composer configuration to add compatible classes.
+
+### Change summary
+
+- All classes are namespaced. See the table in the previous section for the class name mappings.
+- All global variables have now been dropped. This also applies to [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat). They will not be retained or readded.
+- Global constants have been moved to class constants. [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat) adds global mappings back to class constants if you're using it as a drop-in replacement.
+- **All connectivity drivers have been removed**. The only drivers provided are `DoctrineDbal` and `PdoDriver` to connect with Doctrine's DBAL and PDO respectively, and it is _intended_ that all connectivity be performed through one of these two layers.
+- All methods in PEAR have been dropped, except for `isError`, `raiseError` and `throwError`. This includes PEAR's pseudo-destructors.
+- Compatibility names for legacy constructors and '`_Name`' destructors has been removed and placed in [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat).
+- PEAR & DB Error suppression has been removed.
+- Large swathes of code put in place to aid multi-driver compatibility have been removed.
+- Methods marked deprecated have been moved to [wethersherbs/pineapple-compat](https://github.com/wethersherbs/pineapple-compat). Try not to use them. Some methods have been removed entirely.
+- Spit, polish & PSR-2. Refactoring to support some more modern aspects of PHP (e.g. method statics replaced with class statics).
+- Three new exceptions for unhandled events (which would normally cause a `die`): `DriverException`, `FeatureException`, `StatementException`.
+- Don't use `connect()`, use `factory()` and set the connection using `setConnectionHandle()`.
+
+It would not take a large amount of effort to refactor your code to avoid using the compatibility layer, but it is provided for your convenience.
 
 ## Test suite
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-pdo": "*"
     },
     "suggest": {
-        "doctrine/dbal": "DoctrineDbal driver requires Doctrine DBAL to be installed"
+        "doctrine/dbal": "DoctrineDbal driver requires Doctrine DBAL >=2.5 to be installed"
     },
     "scripts": {
         "test": "phpunit --coverage-html='coverage/' --coverage-text='php://stdout' --colors=auto test/"
@@ -30,6 +30,6 @@
         "phpunit/phpunit": "^5.4",
         "diablomedia/phpunit-pretty-printer": "^1.0",
         "ext-pdo_sqlite": "*",
-        "doctrine/dbal": ">=2.0"
+        "doctrine/dbal": ">=2.5"
     }
 }

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -853,7 +853,7 @@ abstract class Common extends Util
      * $res = $db->execute($sth, $data);
      * ```
      *
-     * @param resource $stmt  a DB statement resource returned from prepare()
+     * @param int      $stmt  a DB statement number returned from prepare()
      * @param mixed    $data  array, string or numeric data to be used in
      *                        execution of the statement.  Quantity of items
      *                        passed must match quantity of placeholders in

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -44,10 +44,7 @@ use stdClass;
  */
 abstract class Common extends Util
 {
-    /**
-     * The current default fetch mode
-     * @var integer
-     */
+    /** @var integer The current default fetch mode */
     protected $fetchmode = DB::DB_FETCHMODE_ORDERED;
 
     /**
@@ -73,16 +70,10 @@ abstract class Common extends Util
      */
     public $lastQuery = '';
 
-    /**
-     * A flag to indicate that the author is prepared to make some poor life choices
-     *
-     * @var boolean
-     */
+    /** @var boolean A flag to indicate that the author is prepared to make some poor life choices */
     protected $acceptConsequencesOfPoorCodingChoices = false;
 
-    /**
-     * @var mixed Database connection handle
-     */
+    /** @var mixed Database connection handle */
     protected $connection = null;
 
     /**
@@ -108,35 +99,19 @@ abstract class Common extends Util
      */
     public $lastParameters = [];
 
-    /**
-     * The elements from each prepared statement
-     * @var array
-     */
+    /** @var array The elements from each prepared statement */
     protected $prepareTokens = [];
 
-    /**
-     * The data types of the various elements in each prepared statement
-     * @var array
-     */
+    /** @var array The data types of the various elements in each prepared statement */
     protected $prepareTypes = [];
 
-    /**
-     * The prepared queries
-     * @var array
-     */
+    /** @var array The prepared queries */
     protected $preparedQueries = [];
 
-    /**
-     * Flag indicating that the last query was a manipulation query.
-     * @var boolean
-     */
+    /** @var boolean Flag indicating that the last query was a manipulation query */
     protected $lastQueryManip = false;
 
-    /**
-     * Flag indicating that the next query <em>must</em> be a manipulation
-     * query.
-     * @var boolean
-     */
+    /** @var boolean Flag indicating that the next query _must_ be a manipulation query */
     protected $nextQueryManip = false;
 
     /**

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1201,6 +1201,7 @@ abstract class Common extends Util
             return $res;
         }
 
+        $row = [];
         $err = $res->fetchInto($row, $fetchmode);
 
         $res->free();
@@ -1511,6 +1512,7 @@ abstract class Common extends Util
         }
 
         $results = [];
+        $row = [];
         while (DB::DB_OK === $res->fetchInto($row, $fetchmode)) {
             if ($fetchmode & DB::DB_FETCHMODE_FLIPPED) {
                 foreach ($row as $key => $val) {

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1850,6 +1850,18 @@ abstract class Common extends Util
     }
 
     /**
+     * Retrieve the value used to populate an auto-increment or primary key
+     * field by the DBMS.
+     *
+     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
+     * @return string|Error    The auto-insert ID, an error if unsupported
+     */
+    public function lastInsertId($sequence = null)
+    {
+        return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
+    }
+
+    /**
      * Checks if the given query is a manipulation query. This also takes into
      * account the nextQueryManip flag and sets the lastQueryManip flag
      * (and resets nextQueryManip) according to the result.

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1855,6 +1855,8 @@ abstract class Common extends Util
      *
      * @param string $sequence The name of the sequence (optional, only applies to supported engines)
      * @return string|Error    The auto-insert ID, an error if unsupported
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function lastInsertId($sequence = null)
     {

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1032,7 +1032,7 @@ abstract class Common extends Util
      * Sends a query to the database server
      *
      * The query string can be either a normal statement to be sent directly
-     * to the server OR if <var>$params</var> are passed the query can have
+     * to the server OR if `$params` are passed the query can have
      * placeholders and it will be passed through prepare() and execute().
      *
      * @param string $query   the SQL query or the statement to prepare

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -372,4 +372,34 @@ trait PdoCommonMethods
 
         return $res;
     }
+    
+    /**
+     * Retrieve the value used to populate an auto-increment or primary key
+     * field by the DBMS.
+     *
+     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
+     * @return string|Error    The auto-insert ID, an error if unsupported
+     */
+    public function lastInsertId($sequence = null)
+    {
+        try {
+            $sequenceValue = $this->connection->lastInsertId($sequence);
+            // can't "generate" a fault in a platform within which sequences are supported, so...
+            // @codeCoverageIgnoreStart
+        } catch (PDOException $sequenceException) {
+            return $this->raiseError($this->getNativeErrorCode($sequenceException->getCode()));
+            // @codeCoverageIgnoreEnd
+        }
+
+        // non-exception case error handling here
+        if (($this->connection->errorCode() === '00000') || ($this->connection->errorCode() === null)) {
+            // there is no error
+            return $sequenceValue;
+        }
+
+        // can't "generate" a fault in a platform within which sequences are supported, so...
+        // @codeCoverageIgnoreStart
+        return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
+        // @codeCoverageIgnoreEnd
+    }
 }

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -198,4 +198,13 @@ interface DriverInterface
      * @see Pineapple\DB\Driver\Common::setOption()
      */
     public function tableInfo($result, $mode = null);
+
+    /**
+     * Retrieve the value used to populate an auto-increment or primary key
+     * field by the DBMS.
+     *
+     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
+     * @return string|Error    The auto-insert ID, an error if unsupported
+     */
+    public function lastInsertId($sequence = null);
 }

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -206,4 +206,102 @@ interface DriverInterface
      * @return string|Error    The auto-insert ID, an error if unsupported
      */
     public function lastInsertId($sequence = null);
+
+    /**
+     * Returns the value of an option
+     *
+     * @param string $option  the option name you're curious about
+     * @return mixed  the option's value
+     */
+    public function getOption($option);
+
+    /**
+     * Gets the fetch mode that is used by default for query result
+     *
+     * @return integer A value representing DB::DB_FETCHMODE_* constant
+     * @see DB::DB_FETCHMODE_ASSOC
+     * @see DB::DB_FETCHMODE_ORDERED
+     * @see DB::DB_FETCHMODE_OBJECT
+     * @see DB::DB_FETCHMODE_DEFAULT
+     * @see DB::DB_FETCHMODE_FLIPPED
+     */
+    public function getFetchMode();
+
+    /**
+     * Gets the class used to map rows into objects for DB::DB_FETCHMODE_OBJECT
+     *
+     * @return string The class used to map rows
+     * @see Pineapple\DB\Row
+     */
+    public function getFetchModeObjectClass();
+
+    /**
+     * Gets an advertised feature of the driver
+     *
+     * @param string $feature Name of the feature to return
+     */
+    public function getFeature($feature);
+
+    /**
+     * Sends a query to the database server
+     *
+     * The query string can be either a normal statement to be sent directly
+     * to the server OR if `$params` are passed the query can have
+     * placeholders and it will be passed through prepare() and execute().
+     *
+     * @param string $query   the SQL query or the statement to prepare
+     * @param mixed  $params  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @return mixed          a new Result object for successful SELECT queries
+     *                        or DB_OK for successul data manipulation queries.
+     *                        A Pineapple\DB\Error object on failure.
+     *
+     * @see Result, Common::prepare(), Common::execute()
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    public function query($query, $params = []);
+
+    /**
+     * Communicates an error and invoke error callbacks, etc
+     *
+     * Basically a wrapper for Pineapple\Util::raiseError without the message string.
+     *
+     * @param mixed  integer error code, or a Pineapple\Error object (all
+     *               other parameters are ignored if this parameter is
+     *               an object
+     * @param int    error mode, see Pineapple\Error docs
+     * @param mixed  if error mode is PEAR_ERROR_TRIGGER, this is the
+     *               error level (E_USER_NOTICE etc).  If error mode is
+     *               PEAR_ERROR_CALLBACK, this is the callback function,
+     *               either as a function name, or as an array of an
+     *               object and method name. For other error modes this
+     *               parameter is ignored.
+     * @param string extra debug information. Defaults to the last
+     *               query and native error code.
+     * @param mixed  native error code, integer or string depending the
+     *               backend
+     * @param mixed  dummy parameter for E_STRICT compatibility with
+     *               Pineapple\Util::raiseError
+     * @param mixed  dummy parameter for E_STRICT compatibility with
+     *               Pineapple\Util::raiseError
+     * @return Error the Pineapple\Error object
+     *
+     * @see Pineapple\Error
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function raiseError(
+        $code = DB::DB_ERROR,
+        $mode = null,
+        $options = null,
+        $userInfo = null,
+        $nativecode = null,
+        $dummy1 = null,
+        $dummy2 = null
+    );
 }

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -185,13 +185,12 @@ interface DriverInterface
     /**
      * Returns information about a table or a result set
      *
-     * @param PDOStatement|string $result Pineapple\DB\Result object from a query or a
-     *                                    string containing the name of a table.
-     *                                    While this also accepts a query result
-     *                                    resource identifier, this behavior is
-     *                                    deprecated.
-     * @param int                 $mode   a valid tableInfo mode
-     *
+     * @param StatementContainer|string $result Pineapple\DB\Result object from a query or a
+     *                                          string containing the name of a table.
+     *                                          While this also accepts a query result
+     *                                          resource identifier, this behavior is
+     *                                          deprecated.
+     * @param int                       $mode   a valid tableInfo mode
      * @return mixed   an associative array with the information requested.
      *                 A Pineapple\DB\Error object on failure.
      *

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -114,7 +114,7 @@ class PdoDriver extends Common implements DriverInterface
                     // sqlite supports transactions so this can't be tested right now
                     // @codeCoverageIgnoreStart
                     return $this->raiseError(
-                        DB::ERROR,
+                        DB::DB_ERROR,
                         null,
                         null,
                         self::formatErrorInfo($this->connection->errorInfo())

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -335,8 +335,11 @@ class PdoDriver extends Common implements DriverInterface
     {
         try {
             $sequenceValue = $this->connection->lastInsertId($sequence);
+            // can't "generate" a fault in a platform within which sequences are supported, so...
+            // @codeCoverageIgnoreStart
         } catch (PDOException $sequenceException) {
             return $this->raiseError($this->getNativeErrorCode($sequenceException->getCode()));
+            // @codeCoverageIgnoreEnd
         }
 
         // non-exception case error handling here
@@ -345,7 +348,10 @@ class PdoDriver extends Common implements DriverInterface
             return $sequenceValue;
         }
 
+        // can't "generate" a fault in a platform within which sequences are supported, so...
+        // @codeCoverageIgnoreStart
         return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -325,6 +325,30 @@ class PdoDriver extends Common implements DriverInterface
     }
 
     /**
+     * Retrieve the value used to populate an auto-increment or primary key
+     * field by the DBMS.
+     *
+     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
+     * @return string|Error    The auto-insert ID, an error if unsupported
+     */
+    public function lastInsertId($sequence = null)
+    {
+        try {
+            $sequenceValue = $this->connection->lastInsertId($sequence);
+        } catch (PDOException $sequenceException) {
+            return $this->raiseError($this->getNativeErrorCode($sequenceException->getCode()));
+        }
+
+        // non-exception case error handling here
+        if (($this->connection->errorCode() === '00000') || ($this->connection->errorCode() === null)) {
+            // there is no error
+            return $sequenceValue;
+        }
+
+        return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
+    }
+
+    /**
      * Obtain a "rationalised" database major name
      * n.b. we won't test this, in future it would make sense to see the purpose removed.
      *

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -325,36 +325,6 @@ class PdoDriver extends Common implements DriverInterface
     }
 
     /**
-     * Retrieve the value used to populate an auto-increment or primary key
-     * field by the DBMS.
-     *
-     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
-     * @return string|Error    The auto-insert ID, an error if unsupported
-     */
-    public function lastInsertId($sequence = null)
-    {
-        try {
-            $sequenceValue = $this->connection->lastInsertId($sequence);
-            // can't "generate" a fault in a platform within which sequences are supported, so...
-            // @codeCoverageIgnoreStart
-        } catch (PDOException $sequenceException) {
-            return $this->raiseError($this->getNativeErrorCode($sequenceException->getCode()));
-            // @codeCoverageIgnoreEnd
-        }
-
-        // non-exception case error handling here
-        if (($this->connection->errorCode() === '00000') || ($this->connection->errorCode() === null)) {
-            // there is no error
-            return $sequenceValue;
-        }
-
-        // can't "generate" a fault in a platform within which sequences are supported, so...
-        // @codeCoverageIgnoreStart
-        return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
      * Obtain a "rationalised" database major name
      * n.b. we won't test this, in future it would make sense to see the purpose removed.
      *

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -42,33 +42,23 @@ class PdoDriver extends Common implements DriverInterface
         'transactions' => true,
     ];
 
-    // @var PDO Our PDO connection
+    /** @var PDO Our PDO connection */
     protected $connection = null;
 
-    /**
-     * A copy of the last pdostatement object
-     * @var StatementContainer
-     */
+    /** @var StatementContainer A copy of the last pdostatement object */
     private $lastStatement = null;
 
-    /**
-     * Should data manipulation queries be committed automatically?
-     * @var bool
-     */
+    /** @var boolean Should data manipulation queries be committed automatically? */
     protected $autocommit = true;
 
-    /**
-     * The quantity of transactions begun
-     *
-     * @var integer
-     */
+    /** @var integer The quantity of transactions begun */
     private $transactionOpcount = 0;
 
     /**
      * Set the PDO connection handle in the object
      *
-     * @param PDO        $connection A constructed PDO connection handle
-     * @return PdoDriver             The constructed Pineapple\DB\Driver\PdoDriver object
+     * @param PDO $connection A constructed PDO connection handle
+     * @return PdoDriver      The constructed Pineapple\DB\Driver\PdoDriver object
      */
     public function setConnectionHandle(PDO $connection)
     {
@@ -81,7 +71,6 @@ class PdoDriver extends Common implements DriverInterface
      * Sends a query to the database server
      *
      * @param string $query the SQL query string
-     *
      * @return mixed        a StatementContainer object for successful SELECT
      *                      queries the DB_OK constant for other successful
      *                      queries a Pineapple\DB\Error object on failure.

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -343,8 +343,8 @@ class Result
         if (DB::isError($err)) {
             return $err;
         }
-        $this->result = false;
-        $this->statement = false;
+        unset($this->result);
+        unset($this->statement);
         return true;
     }
 

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -1325,4 +1325,12 @@ class CommonTest extends TestCase
                AND artist = "depeche mode"
         '));
     }
+
+    public function testLastInsertId()
+    {
+        $dbh = DB::factory(TestDriver::class);
+        $insertId = $dbh->lastInsertId();
+        $this->assertInstanceOf(Error::class, $insertId);
+        $this->assertEquals(DB::DB_ERROR_UNSUPPORTED, $insertId->getCode());
+    }
 }

--- a/test/DB/Driver/DoctrineDbalTest.php
+++ b/test/DB/Driver/DoctrineDbalTest.php
@@ -513,4 +513,10 @@ class DoctrineDbalTest extends TestCase
             ],
         ], $tableInfo);
     }
+
+    public function testLastInsertId()
+    {
+        $this->dbh->query('INSERT INTO dbaltest (a) VALUES (\'lama farmer\')');
+        $this->assertEquals(5, $this->dbh->lastInsertId());
+    }
 }

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -528,4 +528,10 @@ class PdoDriverTest extends TestCase
             ],
         ], $tableInfo);
     }
+
+    public function testLastInsertId()
+    {
+        $this->dbh->query('INSERT INTO pdotest (a) VALUES (\'lama farmer\')');
+        $this->assertEquals(5, $this->dbh->lastInsertId());
+    }
 }

--- a/test/DB/Driver/TestDriver.php
+++ b/test/DB/Driver/TestDriver.php
@@ -310,6 +310,11 @@ class TestDriver extends Common implements DriverInterface
         return parent::modifyLimitQuery($query, $from, $count, $params);
     }
 
+    public function stubLastInsertId($sequence = null)
+    {
+        return parent::lastInsertId($sequence);
+    }
+
     public function modifyLimitQuery($query, $from, $count, $params = [])
     {
         if (preg_match('/FAILURE/', $query)) {


### PR DESCRIPTION
Changes since 0.3.0-RC2:

- Add a `lastInsertId()` method to obtain the autoincrement/primary key value for the last statement, since we've made the connection handle private and we'd prefer you didn't resort to the connection object to obtain this.
- More fixes to docblocks to make them accurate.
- Some fixes as per recommendations from phpmd and phan.
- Fix an invalid constant in an exception.

This constitutes the final release of 0.3.0.