### PR TITLE
Version 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - composer require doctrine/dbal ^2.5
 
 script:
-  - ./vendor/bin/phpunit --verbose
+  - ./vendor/bin/phpunit --verbose --colors=auto --coverage-text='php://stdout'
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: php
 php:
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/dbal": "DoctrineDbal driver requires Doctrine DBAL >=2.5 to be installed"
     },
     "scripts": {
-        "test": "phpunit --coverage-html='coverage/' --coverage-text='php://stdout' --colors=auto"
+        "test": "phpunit --colors=auto"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/dbal": "DoctrineDbal driver requires Doctrine DBAL >=2.5 to be installed"
     },
     "scripts": {
-        "test": "phpunit --coverage-html='coverage/' --coverage-text='php://stdout' --colors=auto test/"
+        "test": "phpunit --coverage-html='coverage/' --coverage-text='php://stdout' --colors=auto"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" printerClass="DiabloMedia\PHPUnit\Printer\PrettyPrinter">
+	<logging>
+		<log type="coverage-text" target="php://stdout" />
+		<log type="coverage-html" target="html/" />
+	</logging>
 	<testsuites>
 		<testsuite name="Pineapple test suite">
 			<directory>./test/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit bootstrap="vendor/autoload.php" printerClass="DiabloMedia\PHPUnit\Printer\PrettyPrinter">
 	<logging>
 		<log type="coverage-text" target="php://stdout" />
-		<log type="coverage-html" target="html/" />
+		<log type="coverage-html" target="coverage/" />
 	</logging>
 	<testsuites>
 		<testsuite name="Pineapple test suite">

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1653,7 +1653,6 @@ abstract class Common extends Util
      */
     public function errorCode($nativecode)
     {
-        // @todo put this into -compat and refactor out this method?
         return $this->getNativeErrorCode($nativecode);
     }
 

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -905,7 +905,7 @@ abstract class Common extends Util
                 $fp = @fopen($value, 'rb');
                 if (!$fp) {
                     // @codeCoverageIgnoreStart
-                    // @todo this is a pain to test without vfsStream, so skip for now
+                    // this is a pain to test without vfsStream, so skip for now
                     return $this->raiseError(DB::DB_ERROR_ACCESS_VIOLATION);
                     // @codeCoverageIgnoreEnd
                 }
@@ -1387,11 +1387,10 @@ abstract class Common extends Util
         $results = [];
 
         if ($cols > 2 || $forceArray) {
-            // return array values
-            // @todo this part can be optimized
+            // return array values. this part can be optimized.
 
             /**
-             * @todo I'm acutely aware that this is probably a 50-line bug, because:
+             * @note I'm acutely aware that this is probably a 50-line bug, because:
              * - there's no bitwise ops (meaning combined bits will fall to else block)
              * - it's likely combined flip won't work either
              * - result doesn't handle bitwise either
@@ -1654,7 +1653,7 @@ abstract class Common extends Util
      */
     public function errorCode($nativecode)
     {
-        // @todo put this into -compat and refactor out this method
+        // @todo put this into -compat and refactor out this method?
         return $this->getNativeErrorCode($nativecode);
     }
 

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -231,9 +231,9 @@ abstract class Common extends Util
      *
      * Portability is broken by using the following characters inside
      * delimited identifiers:
-     *   + backtick (<kbd>`</kbd>) -- due to MySQL
-     *   + double quote (<kbd>"</kbd>) -- due to Oracle
-     *   + brackets (<kbd>[</kbd> or <kbd>]</kbd>) -- due to Access
+     *   + backtick (```) -- due to MySQL
+     *   + double quote (`"`) -- due to Oracle
+     *   + brackets (`[` or `]`) -- due to Access
      *
      * Delimited identifiers are known to generally work correctly under
      * the following drivers:
@@ -270,95 +270,45 @@ abstract class Common extends Util
      *
      * @param mixed $property the data to be formatted
      *
-     * @return mixed          the formatted data.  The format depends on the
-     *                        input's PHP type:
-     * <ul>
-     *  <li>
-     *    <kbd>input</kbd> -> <samp>returns</samp>
-     *  </li>
-     *  <li>
-     *    <kbd>null</kbd> -> the string <samp>NULL</samp>
-     *  </li>
-     *  <li>
-     *    <kbd>integer</kbd> or <kbd>double</kbd> -> the unquoted number
-     *  </li>
-     *  <li>
-     *    <kbd>bool</kbd> -> output depends on the driver in use
-     *    Most drivers return integers: <samp>1</samp> if
-     *    <kbd>true</kbd> or <samp>0</samp> if
-     *    <kbd>false</kbd>.
-     *    Some return strings: <samp>TRUE</samp> if
-     *    <kbd>true</kbd> or <samp>FALSE</samp> if
-     *    <kbd>false</kbd>.
-     *    Finally one returns strings: <samp>T</samp> if
-     *    <kbd>true</kbd> or <samp>F</samp> if
-     *    <kbd>false</kbd>. Here is a list of each DBMS,
-     *    the values returned and the suggested column type:
-     *    <ul>
-     *      <li>
-     *        <kbd>dbase</kbd> -> <samp>T/F</samp>
-     *        (<kbd>Logical</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>fbase</kbd> -> <samp>TRUE/FALSE</samp>
-     *        (<kbd>BOOLEAN</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>ibase</kbd> -> <samp>1/0</samp>
-     *        (<kbd>SMALLINT</kbd>) [1]
-     *      </li>
-     *      <li>
-     *        <kbd>ifx</kbd> -> <samp>1/0</samp>
-     *        (<kbd>SMALLINT</kbd>) [1]
-     *      </li>
-     *      <li>
-     *        <kbd>msql</kbd> -> <samp>1/0</samp>
-     *        (<kbd>INTEGER</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>mssql</kbd> -> <samp>1/0</samp>
-     *        (<kbd>BIT</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>mysql</kbd> -> <samp>1/0</samp>
-     *        (<kbd>TINYINT(1)</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>mysqli</kbd> -> <samp>1/0</samp>
-     *        (<kbd>TINYINT(1)</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>oci8</kbd> -> <samp>1/0</samp>
-     *        (<kbd>NUMBER(1)</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>odbc</kbd> -> <samp>1/0</samp>
-     *        (<kbd>SMALLINT</kbd>) [1]
-     *      </li>
-     *      <li>
-     *        <kbd>pgsql</kbd> -> <samp>TRUE/FALSE</samp>
-     *        (<kbd>BOOLEAN</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>sqlite</kbd> -> <samp>1/0</samp>
-     *        (<kbd>INTEGER</kbd>)
-     *      </li>
-     *      <li>
-     *        <kbd>sybase</kbd> -> <samp>1/0</samp>
-     *        (<kbd>TINYINT(1)</kbd>)
-     *      </li>
-     *    </ul>
+     * @return mixed          the formatted data.
+     *
+     * The format depends on the input's PHP type:
+     *   -   `input` -> `returns`
+     *   -   `null` -> the string `NULL`
+     *   -   `integer` or `double` -> the unquoted number
+     *   -   `bool` -> output depends on the driver in use
+     *                 Most drivers return integers: `1` if
+     *                 `true` or `0` if
+     *                 `false`.
+     *                 Some return strings: `TRUE` if
+     *                 `true` or `FALSE` if
+     *                 `false`.
+     *                 Finally one returns strings: `T` if
+     *                 `true` or `F` if
+     *                 `false`. Here is a list of each DBMS,
+     *                 the values returned and the suggested column type:
+     *      -   `dbase` -> `T/F`        (`Logical`)
+     *      -   `fbase` -> `TRUE/FALSE` (`BOOLEAN`)
+     *      -   `ibase` -> `1/0`        (`SMALLINT`) [1]
+     *      -   `ifx` -> `1/0`          (`SMALLINT`) [1]
+     *      -   `msql` -> `1/0`         (`INTEGER`)
+     *      -   `mssql` -> `1/0`        (`BIT`)
+     *      -   `mysql` -> `1/0`        (`TINYINT(1)`)
+     *      -   `mysqli` -> `1/0`       (`TINYINT(1)`)
+     *      -   `oci8` -> `1/0`         (`NUMBER(1)`)
+     *      -   `odbc` -> `1/0`         (`SMALLINT`) [1]
+     *      -   `pgsql` -> `TRUE/FALSE` (`BOOLEAN`)
+     *      -   `sqlite` -> `1/0`       (`INTEGER`)
+     *      -   `sybase` -> `1/0`       (`TINYINT(1)`)
+     *
      *    [1] Accommodate the lowest common denominator because not all
-     *    versions of have <kbd>BOOLEAN</kbd>.
-     *  </li>
-     *  <li>
+     *    versions of have `BOOLEAN`.
+     *
      *    other (including strings and numeric strings) ->
      *    the data with single quotes escaped by preceeding
      *    single quotes, backslashes are escaped by preceeding
      *    backslashes, then the whole string is encapsulated
      *    between single quotes
-     *  </li>
-     * </ul>
      *
      * @see Common::escapeSimple()
      * @since Method available since Release 1.6.0

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -66,9 +66,8 @@ abstract class Common extends Util
     /**
      * The most recently executed query
      * @var string
-     * @todo replace with an accessor
      */
-    public $lastQuery = '';
+    protected $lastQuery = '';
 
     /** @var boolean A flag to indicate that the author is prepared to make some poor life choices */
     protected $acceptConsequencesOfPoorCodingChoices = false;
@@ -132,6 +131,16 @@ abstract class Common extends Util
     public function __construct()
     {
         parent::__construct(Error::class);
+    }
+
+    /**
+     * Retrieve the last query string
+     *
+     * @return string
+     */
+    public function getLastQuery()
+    {
+        return $this->lastQuery;
     }
 
     /**

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1883,4 +1883,19 @@ abstract class Common extends Util
             }
         }
     }
+
+    /**
+     * Change the current database we are working on
+     *
+     * @param string The name of the database to connect to
+     * @return mixed true if the operation worked, Pineapple\DB\Error if it
+     *               failed, Pineapple\DB\Error with DB_ERROR_UNSUPPORTED if
+     *               the feature is not supported by the driver
+     *
+     * @see Pineapple\DB\Error
+     */
+    public function changeDatabase($name)
+    {
+        return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
+    }
 }

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -63,10 +63,7 @@ abstract class Common extends Util
      */
     protected $wasConnected = null;
 
-    /**
-     * The most recently executed query
-     * @var string
-     */
+    /** @var string The most recently executed query */
     protected $lastQuery = '';
 
     /** @var boolean A flag to indicate that the author is prepared to make some poor life choices */
@@ -90,13 +87,8 @@ abstract class Common extends Util
         'strict_transactions' => true,
     ];
 
-    /**
-     * The parameters from the most recently executed query
-     * @var array
-     * @since Property available since Release 1.7.0
-     * @todo Replace with in accessor
-     */
-    public $lastParameters = [];
+    /** @var array The parameters from the most recently executed query */
+    protected $lastParameters = [];
 
     /** @var array The elements from each prepared statement */
     protected $prepareTokens = [];
@@ -126,7 +118,7 @@ abstract class Common extends Util
     protected $features = [];
 
     /**
-     * This constructor calls <kbd>parent::__construct('Pineapple\DB\Error')</kbd>
+     * This constructor calls `parent::__construct('Pineapple\DB\Error')`
      */
     public function __construct()
     {
@@ -141,6 +133,16 @@ abstract class Common extends Util
     public function getLastQuery()
     {
         return $this->lastQuery;
+    }
+
+    /**
+     * Retrieve the last set of parameters used in a query
+     *
+     * @return array
+     */
+    public function getLastParameters()
+    {
+        return $this->lastParameters;
     }
 
     /**

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -1096,7 +1096,7 @@ abstract class Common extends Util
     public function getOne($query, $params = [])
     {
         $row = null;
-        $params = (array)$params;
+        $params = (array) $params;
         // modifyLimitQuery() would be nice here, but it causes BC issues
         if (count($params) > 0) {
             $sth = $this->prepare($query);

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -420,7 +420,8 @@ abstract class Common extends Util
      *
      * @param string $feature  the feature you're curious about
      *
-     * @return bool  whether this driver supports $feature
+     * @return mixed Usually boolean, whether this driver supports $feature,
+     *               in the case of limit a string
      */
     public function provides($feature)
     {

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -459,4 +459,32 @@ trait PdoCommonMethods
         return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
         // @codeCoverageIgnoreEnd
     }
+
+    /**
+     * Change the current database we are working on
+     *
+     * @param string The name of the database to connect to
+     * @return mixed true if the operation worked, Pineapple\DB\Error if it
+     *               failed, Pineapple\DB\Error with DB_ERROR_UNSUPPORTED if
+     *               the feature is not supported by the driver
+     *
+     * @see Pineapple\DB\Error
+     */
+    public function changeDatabase($name)
+    {
+        switch ($this->getPlatform()) {
+            case 'mysql':
+                $this->connection->query('USE ' . $this->quoteIdentifier($name));
+                return $quotedString;
+                break;
+                // @codeCoverageIgnoreEnd
+
+            // not going to try covering this
+            // @codeCoverageIgnoreStart
+            default:
+                return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
+                break;
+            // @codeCoverageIgnoreEnd
+        }
+    }
 }

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -3,6 +3,7 @@ namespace Pineapple\DB\Driver\Components;
 
 use Pineapple\DB;
 use Pineapple\DB\StatementContainer;
+use Pineapple\DB\Result;
 
 /**
  * Common methods shared amongst PDO and PDO-alike drivers.
@@ -357,12 +358,12 @@ trait PdoCommonMethods
             // @codeCoverageIgnoreStart
             $tableHandle = new StatementContainer($this->simpleQuery("SELECT * FROM $result LIMIT 0"));
             // @codeCoverageIgnoreEnd
-        } elseif (is_object($result) && isset($result->result)) {
+        } elseif (is_object($result) && ($result instanceof Result)) {
             /**
              * Probably received a result object.
              * Extract the result resource identifier.
              */
-            $tableHandle = $result->result;
+            $tableHandle = $result->getResult();
         } else {
             return $this->myRaiseError();
         }

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -354,6 +354,10 @@ trait PdoCommonMethods
         for ($i = 0; $i < $count; $i++) {
             $tmp = $tableHandle->getColumnMeta($i);
 
+            if ($tmp === false) {
+                return $this->myRaiseError(DB::DB_ERROR_UNSUPPORTED);
+            }
+
             $res[$i] = [
                 'table' => $caseFunc($tmp['table']),
                 'name' => $caseFunc($tmp['name']),

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -355,7 +355,7 @@ trait PdoCommonMethods
             $tmp = $tableHandle->getColumnMeta($i);
 
             if ($tmp === false) {
-                return $this->raiseError(DB::DB_ERROR, null, null, 'Result set empty or unsupported by driver');
+                next;
             }
 
             $res[$i] = [

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -15,6 +15,42 @@ use Pineapple\DB\StatementContainer;
 trait PdoCommonMethods
 {
     /**
+     * PDO driver types mapping to types as formerly output by PEAR DB
+     */
+    private static $typeMap = [
+        // mysql types
+        'STRING' => 'string',
+        'VAR_STRING' => 'string',
+        'BIT' => 'int',
+        'TINY' => 'int',
+        'SHORT' => 'int',
+        'LONG' => 'int',
+        'LONGLONG' => 'int',
+        'INT24' => 'int',
+        'FLOAT' => 'real',
+        'DOUBLE' => 'real',
+        'DECIMAL' => 'real',
+        'NEWDECIMAL' => 'real',
+        'TIMESTAMP' => 'timestamp',
+        'YEAR' => 'year',
+        'DATE' => 'date',
+        'NEWDATE' => 'date',
+        'TIME' => 'time',
+        'SET' => 'set',
+        'ENUM' => 'enum',
+        'GEOMETRY' => 'geometry',
+        'DATETIME' => 'datetime',
+        'TINY_BLOB' => 'blob',
+        'MEDIUM_BLOB' => 'blob',
+        'LONG_BLOB' => 'blob',
+        'BLOB' => 'blob',
+        'NULL' => 'null',
+
+        // sqlite types
+        'string' => 'string',
+    ];
+
+    /**
      * Disconnects from the database server
      *
      * @return bool     true on success, false on failure
@@ -355,13 +391,30 @@ trait PdoCommonMethods
             $tmp = $tableHandle->getColumnMeta($i);
 
             if ($tmp === false) {
+                // @codeCoverageIgnoreStart
+                // skipping coverage on this because we can't reproduce in test
                 next;
+                // @codeCoverageIgnoreEnd
             }
+
+            if (!isset($tmp['native_type'])) {
+                // @codeCoverageIgnoreStart
+                // skipping coverage on this because we can't reproduce in test
+                $tmp['native_type'] = 'unknown';
+                // @codeCoverageIgnoreEnd
+            }
+
+            // @codeCoverageIgnoreStart
+            // skipping coverage on this because we can't reproduce in test
+            $tmp['native_type'] = isset(self::$typeMap[$tmp['native_type']])
+                ? self::$typeMap[$tmp['native_type']]
+                : 'unknown';
+            // @codeCoverageIgnoreEnd
 
             $res[$i] = [
                 'table' => $caseFunc($tmp['table']),
                 'name' => $caseFunc($tmp['name']),
-                'type' => isset($tmp['native_type']) ? $tmp['native_type'] : 'unknown',
+                'type' => $tmp['native_type'],
                 'len' => $tmp['len'],
                 'flags' => is_array($tmp['flags']) ? implode(' ', $tmp['flags']) : '',
             ];

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -128,7 +128,7 @@ trait PdoCommonMethods
      *                                   object on failure.
      *
      * @see Pineapple\DB\Result::numRows()
-     * @todo This is not easily testable, since not all drivers support this for SELECTs
+     * This is not easily testable, since not all drivers support this for SELECTs, so:
      * @codeCoverageIgnore
      */
     public function numRows(StatementContainer $result)

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -464,27 +464,24 @@ trait PdoCommonMethods
      * Change the current database we are working on
      *
      * @param string The name of the database to connect to
-     * @return mixed true if the operation worked, Pineapple\DB\Error if it
-     *               failed, Pineapple\DB\Error with DB_ERROR_UNSUPPORTED if
-     *               the feature is not supported by the driver
+     * @return mixed DB::DB_OK if the operation worked, Pineapple\DB\Error if
+     *               it failed, Pineapple\DB\Error with DB_ERROR_UNSUPPORTED
+     *               if the feature is not supported by the driver
      *
      * @see Pineapple\DB\Error
+     * @codeCoverageIgnore Skipping coverage because we don't have MySQL
+     *                     integration tests
      */
     public function changeDatabase($name)
     {
         switch ($this->getPlatform()) {
             case 'mysql':
-                $this->connection->query('USE ' . $this->quoteIdentifier($name));
-                return $quotedString;
+                return $this->simpleQuery('USE ' . $this->quoteIdentifier($name));
                 break;
-                // @codeCoverageIgnoreEnd
 
-            // not going to try covering this
-            // @codeCoverageIgnoreStart
             default:
                 return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
                 break;
-            // @codeCoverageIgnoreEnd
         }
     }
 }

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -363,7 +363,7 @@ trait PdoCommonMethods
                 'name' => $caseFunc($tmp['name']),
                 'type' => isset($tmp['native_type']) ? $tmp['native_type'] : 'unknown',
                 'len' => $tmp['len'],
-                'flags' => $tmp['flags'],
+                'flags' => is_array($tmp['flags']) ? implode(' ', $tmp['flags']) : '',
             ];
 
             if ($mode & DB::DB_TABLEINFO_ORDER) {

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -372,7 +372,7 @@ trait PdoCommonMethods
 
         return $res;
     }
-    
+
     /**
      * Retrieve the value used to populate an auto-increment or primary key
      * field by the DBMS.

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -355,7 +355,7 @@ trait PdoCommonMethods
             $tmp = $tableHandle->getColumnMeta($i);
 
             if ($tmp === false) {
-                return $this->myRaiseError(DB::DB_ERROR_UNSUPPORTED);
+                return $this->raiseError(DB::DB_ERROR, null, null, 'Result set empty or unsupported by driver');
             }
 
             $res[$i] = [

--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -171,7 +171,7 @@ class DoctrineDbal extends Common implements DriverInterface
             }
         } else {
             try {
-                $arr = self::getStatement($result)->fetch(PDO::FETCH_NUM);
+                $arr = self::getStatement($result)->fetch(PDO::FETCH_NUM, null, $rownum);
                 // this exception handle was added as the php docs implied a potential exception, which i have thus
                 // far been unable to reproduce.
                 // @codeCoverageIgnoreStart

--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -117,8 +117,8 @@ class DoctrineDbal extends Common implements DriverInterface
             $this->transactionOpcount++;
         }
 
-        // @todo this needs setting on the prepare() driver options, which doctrine doesn't support
         // @codeCoverageIgnoreStart
+        // this needs setting on the prepare() driver options, which doctrine doesn't support
         if (($this->getPlatform() === 'mysql') && !$this->options['result_buffering']) {
             return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
         }
@@ -210,8 +210,8 @@ class DoctrineDbal extends Common implements DriverInterface
 
             try {
                 $this->connection->commit();
-                // @todo honestly, i don't know how to generate a failed transaction commit
                 // @codeCoverageIgnoreStart
+                // honestly, i don't know how to generate a failed transaction commit
             } catch (DBALConnectionException $e) {
                 return $this->myRaiseError();
                 // @codeCoverageIgnoreEnd
@@ -237,8 +237,8 @@ class DoctrineDbal extends Common implements DriverInterface
 
             try {
                 $this->connection->rollBack();
-                // @todo honestly, i don't know how to generate a failed tranascation rollback
                 // @codeCoverageIgnoreStart
+                // honestly, i don't know how to generate a failed tranascation rollback
             } catch (DBALConnectionException $e) {
                 return $this->myRaiseError();
                 // @codeCoverageIgnoreEnd

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -304,4 +304,16 @@ interface DriverInterface
         $dummy1 = null,
         $dummy2 = null
     );
+
+    /**
+     * Change the current database we are working on
+     *
+     * @param string The name of the database to connect to
+     * @return mixed true if the operation worked, Pineapple\DB\Error if it
+     *               failed, Pineapple\DB\Error with DB_ERROR_UNSUPPORTED if
+     *               the feature is not supported by the driver
+     *
+     * @see Pineapple\DB\Error
+     */
+    public function changeDatabase($name);
 }

--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -6,6 +6,160 @@ use Pineapple\DB\StatementContainer;
 interface DriverInterface
 {
     /**
+     * Constructor (only calls the constructor within `Util` with the DB\Error class)
+     */
+    public function __construct();
+
+    /**
+     * Retrieve the last query string
+     *
+     * @return string
+     */
+    public function getLastQuery();
+
+    /**
+     * Retrieve the last set of parameters used in a query
+     *
+     * @return array
+     */
+    public function getLastParameters();
+
+    /**
+     * Gets an advertised feature of the driver
+     *
+     * @param string $feature Name of the feature to return
+     */
+    public function getFeature($feature);
+
+    /**
+     * Accept that your UPDATE without a WHERE is going to update a lot of
+     * data and that you understand the consequences.
+     *
+     * @param boolean $flag true to make UPDATE without WHERE work
+     * @since Method available since Pineapple 0.1.0
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function setAcceptConsequencesOfPoorCodingChoices($flag = false);
+
+    /**
+     * Formats input so it can be safely used in a query
+     *
+     * The output depends on the PHP data type of input and the database
+     * type being used.
+     *
+     * @param mixed $property the data to be formatted
+     *
+     * @return mixed          the formatted data.
+     *
+     * The format depends on the input's PHP type:
+     *   -   `input` -> `returns`
+     *   -   `null` -> the string `NULL`
+     *   -   `integer` or `double` -> the unquoted number
+     *   -   `bool` -> output depends on the driver in use
+     *                 Most drivers return integers: `1` if
+     *                 `true` or `0` if
+     *                 `false`.
+     *                 Some return strings: `TRUE` if
+     *                 `true` or `FALSE` if
+     *                 `false`.
+     *                 Finally one returns strings: `T` if
+     *                 `true` or `F` if
+     *                 `false`. Here is a list of each DBMS,
+     *                 the values returned and the suggested column type:
+     *      -   `dbase` -> `T/F`        (`Logical`)
+     *      -   `fbase` -> `TRUE/FALSE` (`BOOLEAN`)
+     *      -   `ibase` -> `1/0`        (`SMALLINT`) [1]
+     *      -   `ifx` -> `1/0`          (`SMALLINT`) [1]
+     *      -   `msql` -> `1/0`         (`INTEGER`)
+     *      -   `mssql` -> `1/0`        (`BIT`)
+     *      -   `mysql` -> `1/0`        (`TINYINT(1)`)
+     *      -   `mysqli` -> `1/0`       (`TINYINT(1)`)
+     *      -   `oci8` -> `1/0`         (`NUMBER(1)`)
+     *      -   `odbc` -> `1/0`         (`SMALLINT`) [1]
+     *      -   `pgsql` -> `TRUE/FALSE` (`BOOLEAN`)
+     *      -   `sqlite` -> `1/0`       (`INTEGER`)
+     *      -   `sybase` -> `1/0`       (`TINYINT(1)`)
+     *
+     *    [1] Accommodate the lowest common denominator because not all
+     *    versions of have `BOOLEAN`.
+     *
+     *    other (including strings and numeric strings) ->
+     *    the data with single quotes escaped by preceeding
+     *    single quotes, backslashes are escaped by preceeding
+     *    backslashes, then the whole string is encapsulated
+     *    between single quotes
+     *
+     * @see Common::escapeSimple()
+     * @since Method available since Release 1.6.0
+     */
+    public function quoteSmart($property);
+
+    /**
+     * Escapes a string according to the current DBMS's standards
+     *
+     * In SQLite, this makes things safe for inserts/updates, but may
+     * cause problems when performing text comparisons against columns
+     * containing binary data. See the
+     * {@link http://php.net/sqlite_escape_string PHP manual} for more info.
+     *
+     * @param string $str  the string to be escaped
+     *
+     * @return string  the escaped string
+     *
+     * @see Common::quoteSmart()
+     * @since Method available since Release 1.6.0
+     */
+    public function escapeSimple($str);
+
+    /**
+     * Tells whether the present driver supports a given feature
+     *
+     * @param string $feature  the feature you're curious about
+     *
+     * @return mixed Usually boolean, whether this driver supports $feature,
+     *               in the case of limit a string
+     */
+    public function provides($feature);
+
+    /**
+     * Sets the fetch mode that should be used by default for query results
+     *
+     * @param integer $fetchmode    DB_FETCHMODE_ORDERED, DB_FETCHMODE_ASSOC
+     *                               or DB_FETCHMODE_OBJECT
+     * @param string $objectClass   the class name of the object to be returned
+     *                               by the fetch methods when the
+     *                               DB_FETCHMODE_OBJECT mode is selected.
+     *                               If no class is specified by default a cast
+     *                               to object from the assoc array row will be
+     *                               done.  There is also the posibility to use
+     *                               and extend the 'Pineapple\DB\Row' class.
+     *
+     * @see DB_FETCHMODE_ORDERED, DB_FETCHMODE_ASSOC, DB_FETCHMODE_OBJECT
+     */
+    public function setFetchMode($fetchmode, $objectClass = stdClass::class);
+
+    /**
+     * Gets the fetch mode that is used by default for query result
+     *
+     * @return integer A value representing DB::DB_FETCHMODE_* constant
+     * @see DB::DB_FETCHMODE_ASSOC
+     * @see DB::DB_FETCHMODE_ORDERED
+     * @see DB::DB_FETCHMODE_OBJECT
+     * @see DB::DB_FETCHMODE_DEFAULT
+     * @see DB::DB_FETCHMODE_FLIPPED
+     */
+    public function getFetchMode();
+
+    /**
+     * Gets the class used to map rows into objects for DB::DB_FETCHMODE_OBJECT
+     *
+     * @return string The class used to map rows
+     * @see Pineapple\DB\Row
+     */
+    public function getFetchModeObjectClass();
+
+    /**
      * Get a Pineapple DB error code from a driver-specific error code,
      * returning a standard 'generic error' if unmappable.
      *
@@ -14,6 +168,303 @@ interface DriverInterface
      * @return int         The DB::DB_ERROR_* constant
      */
     public function getNativeErrorCode($code);
+
+    /**
+     * Sets run-time configuration options
+     *
+     * Options, their data types, default values and description:
+     *
+     * - `autofree` (boolean) = `false`
+     *   should results be freed automatically when there are no more rows?
+     *
+     * - `result_buffering` (integer) = `500`
+     *   how many rows of the result set should be buffered?
+     *   Supported by `PdoDriver`, not by `DoctrineDbal`
+     *
+     * - `debug` (integer) = `0`
+     *   debug level
+     *
+     * - `portability` (integer) = `DB_PORTABILITY_NONE`
+     *   portability mode constant (see below)
+     *
+     * - `seqname_format` (string) = `%s_seq`
+     *   the sprintf() format string used on sequence names. This format is
+     *   applied to sequence names passed to `createSequence()`, `nextID()`
+     *   and `dropSequence()`.
+     *
+     * -----------------------------------------
+     *
+     * PORTABILITY MODES
+     *
+     * These modes are bitwised, so they can be combined using `|` and
+     * removed using `^`. See the examples section below on how to do this.
+     *
+     * - `DB_PORTABILITY_NONE`
+     *   turn off all portability features
+     *
+     * - `DB_PORTABILITY_LOWERCASE`
+     *   convert names of tables and fields to lower case when using
+     *   `get*()`, `fetch*()` and `tableInfo()`
+     *
+     * - `DB_PORTABILITY_RTRIM`
+     *   right trim the data output by `get*()` `fetch*()`
+     *
+     * - `DB_PORTABILITY_DELETE_COUNT`
+     *   force reporting the number of rows deleted
+     *
+     *   Some DBMS's don't count the number of rows deleted when performing
+     *   simple `DELETE FROM tablename` queries.  This portability
+     *   mode tricks such DBMS's into telling the count by adding
+     *   `WHERE 1=1` to the end of `DELETE` queries.
+     *
+     * - `DB_PORTABILITY_NUMROWS`
+     *   enable hack that makes `numRows()` work in Oracle
+     *
+     *   + mysql, mysqli:  change unique/primary key constraints
+     *     DB_ERROR_ALREADY_EXISTS -> DB_ERROR_CONSTRAINT
+     *
+     * - `DB_PORTABILITY_NULL_TO_EMPTY</samp>
+     *   convert null values to empty strings in data output by get*() and
+     *   fetch*().  Needed because Oracle considers empty strings to be null,
+     *   while most other DBMS's know the difference between empty and null.
+     *
+     * - `DB_PORTABILITY_ALL</samp>
+     *   turn on all portability features
+     *
+     * -----------------------------------------
+     *
+     * Example 1. Simple setOption() example
+     * ```php
+     * $db->setOption('autofree', true);
+     * ```
+     *
+     * Example 2. Portability for lowercasing and trimming
+     * ```php
+     * $db->setOption('portability',
+     *                 DB_PORTABILITY_LOWERCASE | DB_PORTABILITY_RTRIM);
+     * ```
+     *
+     * Example 3. All portability options except trimming
+     * ```php
+     * $db->setOption(
+     *     'portability',
+     *     DB::DB_PORTABILITY_ALL ^ DB::DB_PORTABILITY_RTRIM
+      * );
+     * ```
+     *
+     * @param string $option option name
+     * @param mixed  $value  value for the option
+     * @return mixed         DB_OK on success. A Pineapple\DB\Error object on failure.
+     *
+     * @see Common::$options
+     */
+    public function setOption($option, $value);
+
+    /**
+     * Returns the value of an option
+     *
+     * @param string $option  the option name you're curious about
+     * @return mixed  the option's value
+     */
+    public function getOption($option);
+
+    /**
+     * Determine if we're connected
+     *
+     * @return boolean true if connected, false if not
+     */
+    public function connected();
+
+    /**
+     * Prepares a query for multiple execution with execute()
+     *
+     * Creates a query that can be run multiple times.  Each time it is run,
+     * the placeholders, if any, will be replaced by the contents of
+     * execute()'s $data argument.
+     *
+     * Three types of placeholders can be used:
+     *   + `?`  scalar value (i.e. strings, integers).  The system will
+     *          automatically quote and escape the data.
+     *   + `!`  value is inserted 'as is'
+     *   + `&`  requires a file name.  The file's contents get inserted
+     *          into the query (i.e. saving binary data in a db)
+     *
+     * Example 1.
+     * ```php
+     * $sth = $db->prepare('INSERT INTO tbl (a, b, c) VALUES (?, !, &)');
+     * $data = [
+     *     "John's text",
+     *     "'it''s good'",
+     *     'filename.txt'
+     * ];
+     * $res = $db->execute($sth, $data);
+     * ```
+     *
+     * Use backslashes to escape placeholder characters if you don't want
+     * them to be interpreted as placeholders:
+     * ```sql
+     * UPDATE foo SET col=? WHERE col='over \& under'
+     * ```
+     *
+     * With some database backends, this is emulated.
+     *
+     * @param string $query  the query to be prepared
+     * @return mixed         DB statement resource on success. A Pineapple\DB\Error
+     *                       object on failure.
+     *
+     * @see Common::execute()
+     */
+    public function prepare($query);
+
+    /**
+     * Automaticaly generates an insert or update query and pass it to prepare()
+     *
+     * @param string $table         the table name
+     * @param array  $tableFields   the array of field names
+     * @param int    $mode          a type of query to make:
+     *                              DB_AUTOQUERY_INSERT or DB_AUTOQUERY_UPDATE
+     * @param string $where         for update queries: the WHERE clause to
+     *                              append to the SQL statement.  Don't
+     *                              include the "WHERE" keyword.
+     * @return mixed                the query handle
+     *
+     * @uses Common::prepare(), Common::buildManipSQL()
+     */
+    public function autoPrepare($table, $tableFields, $mode = DB::DB_AUTOQUERY_INSERT, $where = null);
+
+    /**
+     * Automaticaly generates an insert or update query and call prepare()
+     * and execute() with it
+     *
+     * @param string $table         the table name
+     * @param array  $fieldsValues  the associative array where $key is a
+     *                              field name and $value its value
+     * @param int    $mode          a type of query to make:
+     *                              DB_AUTOQUERY_INSERT or DB_AUTOQUERY_UPDATE
+     * @param string $where         for update queries: the WHERE clause to
+     *                              append to the SQL statement.  Don't
+     *                              include the "WHERE" keyword.
+     * @return mixed                a new Result object for successful SELECT queries
+     *                              or DB_OK for successul data manipulation queries.
+     *                              A Pineapple\DB\Error object on failure.
+     *
+     * @uses Common::autoPrepare(), Common::execute()
+     */
+    public function autoExecute($table, $fieldsValues, $mode = DB::DB_AUTOQUERY_INSERT, $where = null);
+
+    /**
+     * Produces an SQL query string for autoPrepare()
+     *
+     * Example:
+     * ```php
+     * buildManipSQL('table_sql', ['field1', 'field2', 'field3'],
+     *               DB_AUTOQUERY_INSERT);
+     * ```
+     *
+     * That returns
+     * ```sql
+     * INSERT INTO table_sql (field1,field2,field3) VALUES (?,?,?)
+     * ```
+     *
+     * NOTES:
+     *   - This belongs more to a SQL Builder class, but this is a simple
+     *     facility.
+     *   - Be carefull! If you don't give a $where param with an UPDATE
+     *     query, all the records of the table will be updated!
+     *
+     * @param string $table         the table name
+     * @param array  $tableFields   the array of field names
+     * @param int    $mode          a type of query to make:
+     *                              DB_AUTOQUERY_INSERT or DB_AUTOQUERY_UPDATE
+     * @param string $where         for update queries: the WHERE clause to
+     *                              append to the SQL statement.  Don't
+     *                              include the "WHERE" keyword.
+     * @return string|Error         the sql query for autoPrepare(), or an Error
+     *                              object in the case of failure
+     */
+    public function buildManipSQL($table, $tableFields, $mode, $where = null);
+
+    /**
+     * Executes a DB statement prepared with prepare()
+     *
+     * Example 1.
+     * ```php
+     * $sth = $db->prepare('INSERT INTO tbl (a, b, c) VALUES (?, !, &)');
+     * $data = [
+     *     "John's text",
+     *     "'it''s good'",
+     *     'filename.txt'
+     * ];
+     * $res = $db->execute($sth, $data);
+     * ```
+     *
+     * @param int      $stmt  a DB statement number returned from prepare()
+     * @param mixed    $data  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @return mixed          a new Result object for successful SELECT queries
+     *                        or DB_OK for successul data manipulation queries.
+     *                        A Pineapple\DB\Error object on failure.
+     *
+     * @see Common::prepare()
+     */
+    public function execute($stmt, $data = []);
+
+    /**
+     * Performs several execute() calls on the same statement handle
+     *
+     * $data must be an array indexed numerically
+     * from 0, one execute call is done for every "row" in the array.
+     *
+     * If an error occurs during execute(), executeMultiple() does not
+     * execute the unfinished rows, but rather returns that error.
+     *
+     * @param int   $stmt  query handle from prepare()
+     * @param array $data  numeric array containing the data to insert
+     *                     into the query
+     * @return int         DB_OK on success. A Pineapple\DB\Error object on failure.
+     *
+     * @see Common::prepare(), Common::execute()
+     */
+    public function executeMultiple($stmt, array $data);
+
+    /**
+     * Frees the internal resources associated with a prepared query
+     *
+     * @param int  $stmt         the prepared statement's ID number
+     * @param bool $freeResource should the PHP resource be freed too? Use
+     *                           false if you need to get data from the
+     *                           result set later.
+     * @return bool              true on success, false if $result is invalid
+     *
+     * @see Common::prepare()
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function freePrepared($stmt, $freeResource = true);
+
+    /**
+     * Sends a query to the database server
+     *
+     * The query string can be either a normal statement to be sent directly
+     * to the server OR if `$params` are passed the query can have
+     * placeholders and it will be passed through prepare() and execute().
+     *
+     * @param string $query   the SQL query or the statement to prepare
+     * @param mixed  $params  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @return mixed          a new Result object for successful SELECT queries
+     *                        or DB_OK for successul data manipulation queries.
+     *                        A Pineapple\DB\Error object on failure.
+     *
+     * @see Result, Common::prepare(), Common::execute()
+     */
+    public function query($query, $params = []);
 
     /**
      * Disconnects from the database server
@@ -95,161 +546,51 @@ interface DriverInterface
     public function numCols(StatementContainer $result);
 
     /**
-     * Gets the number of rows in a result set
-     *
-     * This method is not meant to be called directly.  Use
-     * Pineapple\DB\Result::numRows() instead.  It can't be declared "protected"
-     * because Pineapple\DB\Result is a separate object.
-     *
-     * @param mixed $result     PHP's query result resource
-     *
-     * @return int|Error        the number of rows. A Pineapple\DB\Error
-     *                          object on failure.
-     *
-     * @see Pineapple\DB\Result::numRows()
-     */
-    public function numRows(StatementContainer $result);
-
-    /**
-     * Enables or disables automatic commits
-     *
-     * @param bool $onoff  true turns it on, false turns it off
-     *
-     * @return int|Error   DB_OK on success. A Pineapple\DB\Error object if
-     *                     the driver doesn't support auto-committing
-     *                     transactions.
-     *
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
-     */
-    public function autoCommit($onoff = false);
-
-    /**
-     * Commits the current transaction
-     *
-     * @return int|Error  DB_OK on success. A Pineapple\DB\Error object on
-     *                    failure.
-     */
-    public function commit();
-
-    /**
-     * Reverts the current transaction
-     *
-     * @return int|Error  DB_OK on success. A Pineapple\DB\Error object on
-     *                    failure.
-     */
-    public function rollback();
-
-    /**
-     * Determines the number of rows affected by a data maniuplation query
-     *
-     * 0 is returned for queries that don't manipulate data.
-     *
-     * @return int|Error  the number of rows. A Pineapple\DB\Error object
-     *                    on failure.
-     */
-    public function affectedRows();
-
-    /**
      * Quotes a string so it can be safely used as a table or column name
      * (WARNING: using names that require this is a REALLY BAD IDEA)
      *
-     * WARNING:  Older versions of MySQL can't handle the backtick
-     * character (<kbd>`</kbd>) in table or column names.
+     * Delimiting style depends on which database driver is being used.
      *
-     * @param string $str  identifier name to be quoted
+     * NOTE: just because you CAN use delimited identifiers doesn't mean
+     * you SHOULD use them.  In general, they end up causing way more
+     * problems than they solve.
      *
-     * @return string      quoted identifier string
+     * Portability is broken by using the following characters inside
+     * delimited identifiers:
+     *   + backtick (```) -- due to MySQL
+     *   + double quote (`"`) -- due to Oracle
+     *   + brackets (`[` or `]`) -- due to Access
      *
-     * @see Pineapple\DB\Driver\Common::quoteIdentifier()
+     * Delimited identifiers are known to generally work correctly under
+     * the following drivers:
+     *   + mssql
+     *   + mysql
+     *   + mysqli
+     *   + oci8
+     *   + odbc(access)
+     *   + odbc(db2)
+     *   + pgsql
+     *   + sqlite
+     *   + sybase (must execute <kbd>set quoted_identifier on</kbd> sometime
+     *     prior to use)
+     *
+     * InterBase doesn't seem to be able to use delimited identifiers
+     * via PHP 4.  They work fine under PHP 5.
+     *
+     * @param string $str  the identifier name to be quoted
+     *
+     * @return string  the quoted identifier
+     *
+     * @since Method available since Release 1.6.0
      */
     public function quoteIdentifier($str);
 
     /**
-     * Escapes a string according to the current DBMS's standards
+     * Generates and executes a LIMIT query
      *
-     * @param string $str   the string to be escaped
-     *
-     * @return string|Error the escaped string, or an error
-     *
-     * @see Pineapple\DB\Driver\Common::quoteSmart()
-     */
-    public function escapeSimple($str);
-
-    /**
-     * Gets the DBMS' native error code produced by the last query
-     *
-     * @return int  the DBMS' error code
-     */
-    public function errorNative();
-
-    /**
-     * Returns information about a table or a result set
-     *
-     * @param StatementContainer|string $result Pineapple\DB\Result object from a query or a
-     *                                          string containing the name of a table.
-     *                                          While this also accepts a query result
-     *                                          resource identifier, this behavior is
-     *                                          deprecated.
-     * @param int                       $mode   a valid tableInfo mode
-     * @return mixed   an associative array with the information requested.
-     *                 A Pineapple\DB\Error object on failure.
-     *
-     * @see Pineapple\DB\Driver\Common::setOption()
-     */
-    public function tableInfo($result, $mode = null);
-
-    /**
-     * Retrieve the value used to populate an auto-increment or primary key
-     * field by the DBMS.
-     *
-     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
-     * @return string|Error    The auto-insert ID, an error if unsupported
-     */
-    public function lastInsertId($sequence = null);
-
-    /**
-     * Returns the value of an option
-     *
-     * @param string $option  the option name you're curious about
-     * @return mixed  the option's value
-     */
-    public function getOption($option);
-
-    /**
-     * Gets the fetch mode that is used by default for query result
-     *
-     * @return integer A value representing DB::DB_FETCHMODE_* constant
-     * @see DB::DB_FETCHMODE_ASSOC
-     * @see DB::DB_FETCHMODE_ORDERED
-     * @see DB::DB_FETCHMODE_OBJECT
-     * @see DB::DB_FETCHMODE_DEFAULT
-     * @see DB::DB_FETCHMODE_FLIPPED
-     */
-    public function getFetchMode();
-
-    /**
-     * Gets the class used to map rows into objects for DB::DB_FETCHMODE_OBJECT
-     *
-     * @return string The class used to map rows
-     * @see Pineapple\DB\Row
-     */
-    public function getFetchModeObjectClass();
-
-    /**
-     * Gets an advertised feature of the driver
-     *
-     * @param string $feature Name of the feature to return
-     */
-    public function getFeature($feature);
-
-    /**
-     * Sends a query to the database server
-     *
-     * The query string can be either a normal statement to be sent directly
-     * to the server OR if `$params` are passed the query can have
-     * placeholders and it will be passed through prepare() and execute().
-     *
-     * @param string $query   the SQL query or the statement to prepare
+     * @param string $query   the query
+     * @param int    $from    the row to start to fetching (0 = the first row)
+     * @param int    $count   the numbers of rows to fetch
      * @param mixed  $params  array, string or numeric data to be used in
      *                        execution of the statement.  Quantity of items
      *                        passed must match quantity of placeholders in
@@ -258,12 +599,214 @@ interface DriverInterface
      * @return mixed          a new Result object for successful SELECT queries
      *                        or DB_OK for successul data manipulation queries.
      *                        A Pineapple\DB\Error object on failure.
-     *
-     * @see Result, Common::prepare(), Common::execute()
-     *
-     * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function query($query, $params = []);
+    public function limitQuery($query, $from, $count, $params = []);
+
+    /**
+     * Fetches the first column of the first row from a query result
+     *
+     * Takes care of doing the query and freeing the results when finished.
+     *
+     * @param string $query   the SQL query
+     * @param mixed  $params  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @return mixed          the returned value of the query.
+     *                        A Pineapple\DB\Error object on failure.
+     */
+    public function getOne($query, $params = []);
+
+    /**
+     * Fetches the first row of data returned from a query result
+     *
+     * Takes care of doing the query and freeing the results when finished.
+     *
+     * @param string $query   the SQL query
+     * @param mixed  $params  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @param int $fetchmode  the fetch mode to use
+     * @return array|Error    the first row of results as an array.
+     *                        A Pineapple\DB\Error object on failure.
+     */
+    public function getRow($query, $params = [], $fetchmode = DB::DB_FETCHMODE_DEFAULT);
+
+    /**
+     * Fetches a single column from a query result and returns it as an
+     * indexed array
+     *
+     * @param string $query   the SQL query
+     * @param mixed  $col     which column to return (integer [column number,
+     *                        starting at 0] or string [column name])
+     * @param mixed  $params  array, string or numeric data to be used in
+     *                        execution of the statement.  Quantity of items
+     *                        passed must match quantity of placeholders in
+     *                        query:  meaning 1 placeholder for non-array
+     *                        parameters or 1 placeholder per array element.
+     * @return array          the results as an array. A Pineapple\DB\Error object on failure.
+     *
+     * @see Common::query()
+     */
+    public function getCol($query, $col = 0, $params = []);
+
+    /**
+     * Fetches an entire query result and returns it as an
+     * associative array using the first column as the key
+     *
+     * If the result set contains more than two columns, the value
+     * will be an array of the values from column 2-n.  If the result
+     * set contains only two columns, the returned value will be a
+     * scalar with the value of the second column (unless forced to an
+     * array with the $forceArray parameter).  A DB error code is
+     * returned on errors.  If the result set contains fewer than two
+     * columns, a DB_ERROR_TRUNCATED error is returned.
+     *
+     * For example, if the table "mytable" contains:
+     *
+     * | ID | TEXT    | DATE      |
+     * |----|---------|-----------|
+     * | 1  | 'one'   | 944679408 |
+     * | 2  | 'two'   | 944679408 |
+     * | 3  | 'three' | 944679408 |
+     *
+     * Then the call `getAssoc('SELECT id,text FROM mytable')` returns:
+     * ```php
+     *   [
+     *     '1' => 'one',
+     *     '2' => 'two',
+     *     '3' => 'three',
+     *   ]
+     * ```
+     *
+     * ...while the call `getAssoc('SELECT id,text,date FROM mytable')` returns:
+     * ```php
+     *   [
+     *     '1' => ['one', '944679408'],
+     *     '2' => ['two', '944679408'],
+     *     '3' => ['three', '944679408']
+     *   ]
+     * ```
+     *
+     * If the more than one row occurs with the same value in the
+     * first column, the last row overwrites all previous ones by
+     * default.  Use the $group parameter if you don't want to
+     * overwrite like this.  Example:
+     *
+     * `getAssoc('SELECT category,id,name FROM mytable', false, null,
+     *          DB_FETCHMODE_ASSOC, true)` returns:
+     *
+     * ```php
+     *   [
+     *     '1' => [
+     *       ['id' => '4', 'name' => 'number four'],
+     *       ['id' => '6', 'name' => 'number six']
+     *     ],
+     *     '9' => [
+     *       ['id' => '4', 'name' => 'number four'],
+     *       ['id' => '6', 'name' => 'number six']
+     *     ]
+     *   ]
+     * ```
+     *
+     * Keep in mind that database functions in PHP usually return string
+     * values for results regardless of the database's internal type.
+     *
+     * @param string $query        the SQL query
+     * @param bool   $forceArray   used only when the query returns
+     *                             exactly two columns.  If true, the values
+     *                             of the returned array will be one-element
+     *                             arrays instead of scalars.
+     * @param mixed  $params       array, string or numeric data to be used in
+     *                             execution of the statement.  Quantity of
+     *                             items passed must match quantity of
+     *                             placeholders in query:  meaning 1
+     *                             placeholder for non-array parameters or
+     *                             1 placeholder per array element.
+     * @param int   $fetchmode     the fetch mode to use
+     * @param bool  $group         if true, the values of the returned array
+     *                             is wrapped in another array.  If the same
+     *                             key value (in the first column) repeats
+     *                             itself, the values will be appended to
+     *                             this array instead of overwriting the
+     *                             existing values.
+     *
+     * @return array|Error         the associative array containing the query results.
+     *                             A Pineapple\DB\Error object on failure.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function getAssoc(
+        $query,
+        $forceArray = false,
+        $params = [],
+        $fetchmode = DB::DB_FETCHMODE_DEFAULT,
+        $group = false
+    );
+
+    /**
+     * Fetches all of the rows from a query result
+     *
+     * @param string $query     the SQL query
+     * @param mixed  $params    array, string or numeric data to be used in
+     *                          execution of the statement.  Quantity of
+     *                          items passed must match quantity of
+     *                          placeholders in query:  meaning 1
+     *                          placeholder for non-array parameters or
+     *                          1 placeholder per array element.
+     * @param int    $fetchmode the fetch mode to use:
+     *                          - DB_FETCHMODE_ORDERED
+     *                          - DB_FETCHMODE_ASSOC
+     *                          - DB_FETCHMODE_ORDERED | DB_FETCHMODE_FLIPPED
+     *                          - DB_FETCHMODE_ASSOC | DB_FETCHMODE_FLIPPED
+     * @return array            the nested array. A Pineapple\DB\Error object on failure.
+     */
+    public function getAll($query, $params = [], $fetchmode = DB::DB_FETCHMODE_DEFAULT);
+
+    /**
+     * Enables or disables automatic commits
+     *
+     * @param bool $onoff true turns it on, false turns it off
+     * @return int|Error  DB_OK on success. A Pineapple\DB\Error object if
+     *                    the driver doesn't support auto-committing transactions.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function autoCommit($onoff = false);
+
+    /**
+     * Commits the current transaction
+     *
+     * @return int|Error DB_OK on success. A Pineapple\DB\Error object on failure.
+     */
+    public function commit();
+
+    /**
+     * Reverts the current transaction
+     *
+     * @return int|Error DB_OK on success. A Pineapple\DB\Error object on failure.
+     */
+    public function rollback();
+
+    /**
+     * Determines the number of rows in a query result
+     *
+     * @param StatementContainer $result the query result idenifier produced by PHP
+     * @return int|Error                 the number of rows.  A Pineapple\DB\Error object on failure.
+     */
+    public function numRows(StatementContainer $result);
+
+    /**
+     * Determines the number of rows affected by a data maniuplation query
+     *
+     * 0 is returned for queries that don't manipulate data.
+     *
+     * @return int|Error  the number of rows.  A Pineapple\DB\Error object on failure.
+     */
+    public function affectedRows();
 
     /**
      * Communicates an error and invoke error callbacks, etc
@@ -291,9 +834,6 @@ interface DriverInterface
      * @return Error the Pineapple\Error object
      *
      * @see Pineapple\Error
-     *
-     * @SuppressWarnings(PHPMD.StaticAccess)
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function raiseError(
         $code = DB::DB_ERROR,
@@ -304,6 +844,172 @@ interface DriverInterface
         $dummy1 = null,
         $dummy2 = null
     );
+
+    /**
+     * Gets the DBMS' native error code produced by the last query
+     *
+     * @return mixed  the DBMS' error code.  A Pineapple\DB\Error object on failure.
+     */
+    public function errorNative();
+
+    /**
+     * Maps native error codes to DB's portable ones
+     *
+     * @param string|int $nativecode the error code returned by the DBMS
+     * @return int                   the portable DB error code.  Return DB_ERROR if the
+     *                               current driver doesn't have a mapping for the
+     *                               $nativecode submitted.
+     */
+    public function errorCode($nativecode);
+
+    /**
+     * Maps a DB error code to a textual message
+     *
+     * @param int $dbcode the DB error code
+     * @return string     the error message corresponding to the error code
+     *                    submitted.  FALSE if the error code is unknown.
+     *
+     * @see DB::errorMessage()
+     */
+    public function errorMessage($dbcode);
+
+    /**
+     * Returns information about a table or a result set
+     *
+     * The format of the resulting array depends on which <var>$mode</var>
+     * you select.  The sample output below is based on this query:
+     * ```sql
+     *    SELECT tblFoo.fldID, tblFoo.fldPhone, tblBar.fldId
+     *    FROM tblFoo
+     *    JOIN tblBar ON tblFoo.fldId = tblBar.fldId
+     * ```
+     *
+     * `null` (default)
+     *   ```php
+     *   [0] => Array (
+     *       [table] => tblFoo
+     *       [name] => fldId
+     *       [type] => int
+     *       [len] => 11
+     *       [flags] => primary_key not_null
+     *   )
+     *   [1] => Array (
+     *       [table] => tblFoo
+     *       [name] => fldPhone
+     *       [type] => string
+     *       [len] => 20
+     *       [flags] =>
+     *   )
+     *   [2] => Array (
+     *       [table] => tblBar
+     *       [name] => fldId
+     *       [type] => int
+     *       [len] => 11
+     *       [flags] => primary_key not_null
+     *   )
+     *   ```
+     *
+     * `DB_TABLEINFO_ORDER`
+     *
+     * In addition to the information found in the default output, a notation
+     * of the number of columns is provided by the `num_fields` element while
+     * the `order` element provides an array with the column names as the keys
+     * and their location index number (corresponding to the keys in the
+     * default output) as the values.
+     *
+     * If a result set has identical field names, the last one is used.
+     *
+     *   ```php
+     *   [num_fields] => 3
+     *   [order] => Array (
+     *       [fldId] => 2
+     *       [fldTrans] => 1
+     *   )
+     *   ```
+     *
+     * `DB_TABLEINFO_ORDERTABLE`
+     *
+     * Similar to `DB_TABLEINFO_ORDER` but adds more dimensions to the array
+     * in which the table names are keys and the field names are sub-keys.
+     * This is helpful for queries that join tables which have identical
+     * field names.
+     *
+     *   ```php
+     *   [num_fields] => 3
+     *   [ordertable] => Array (
+     *       [tblFoo] => Array (
+     *           [fldId] => 0
+     *           [fldPhone] => 1
+     *       )
+     *       [tblBar] => Array (
+     *           [fldId] => 2
+     *       )
+     *   )
+     *   ```
+     *
+     * The `flags` element contains a space separated list of extra
+     * information about the field.  This data is inconsistent between DBMS's
+     * due to the way each DBMS works.
+     *   + `primary_key`
+     *   + `unique_key`
+     *   + `multiple_key`
+     *   + `not_null`
+     *
+     * Most DBMS's only provide the `table` and `flags` elements if `$result`
+     * is a table name. The following DBMS's provide full information from
+     * queries:
+     *   + fbsql
+     *   + mysql
+     *
+     * If the 'portability' option has `DB_PORTABILITY_LOWERCASE` turned on,
+     * the names of tables and fields will be lowercased.
+     *
+     * @param object|string  $result  Result object from a query or a
+     *                                string containing the name of a table.
+     *                                While this also accepts a query result
+     *                                resource identifier, this behavior is
+     *                                deprecated.
+     * @param int  $mode              either unused or one of the tableInfo modes:
+     *                                `DB_TABLEINFO_ORDERTABLE`,
+     *                                `DB_TABLEINFO_ORDER` or `DB_TABLEINFO_FULL`
+     *                                (which does both). These are bitwise, so the
+     *                                first two can be combined using `|`.
+     * @return array|Error            an associative array with the information requested.
+     *                                A Pineapple\DB\Error object on failure.
+     *
+     * @see Common::setOption()
+     */
+    public function tableInfo($result, $mode = null);
+
+    /**
+     * Sets (or unsets) a flag indicating that the next query will be a
+     * manipulation query, regardless of the usual self::isManip() heuristics.
+     *
+     * @param boolean $manip true to set the flag overriding the isManip() behaviour,
+     *                       false to clear it and fall back onto isManip()
+     */
+    public function nextQueryIsManip($manip);
+
+    /**
+     * Tell whether a query is a data manipulation or data definition query
+     *
+     * Examples of data manipulation queries are INSERT, UPDATE and DELETE.
+     * Examples of data definition queries are CREATE, DROP, ALTER, GRANT,
+     * REVOKE.
+     *
+     * @param string $query the query
+     * @return boolean      whether $query is a data manipulation query
+     */
+    public static function isManip($query);
+
+    /**
+     * Retrieve the value used to populate an auto-increment or primary key
+     * field by the DBMS.
+     *
+     * @param string $sequence The name of the sequence (optional, only applies to supported engines)
+     * @return string|Error    The auto-insert ID, an error if unsupported
+     */
+    public function lastInsertId($sequence = null);
 
     /**
      * Change the current database we are working on

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -124,7 +124,7 @@ class PdoDriver extends Common implements DriverInterface
 
         // prepare the query for execution (we can only inject the unbuffered query parameter on prepared statements)
         try {
-            $statement = $this->connection->prepare($query);
+            $statement = $this->connection->prepare($query, $queryDriverOptions);
         } catch (PDOException $prepareException) {
             return $this->raiseError(DB::DB_ERROR, null, null, $prepareException->getMessage());
         }

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -191,13 +191,13 @@ class PdoDriver extends Common implements DriverInterface
      * Pineapple\DB\Result::fetchInto() instead.  It can't be declared
      * "protected" because Pineapple\DB\Result is a separate object.
      *
-     * @param PDOStatement $result    the query result resource
-     * @param array        $arr       the referenced array to put the data in
-     * @param int          $fetchmode how the resulting array should be indexed
-     * @param int          $rownum    the row number to fetch (0 = first row)
+     * @param StatementContainer $result    the query result resource
+     * @param array              $arr       the referenced array to put the data in
+     * @param int                $fetchmode how the resulting array should be indexed
+     * @param int                $rownum    the row number to fetch (0 = first row)
      *
-     * @return mixed              DB_OK on success, NULL when the end of a
-     *                            result set is reached or on failure
+     * @return mixed                        DB_OK on success, NULL when the end of a
+     *                                      result set is reached or on failure
      *
      * @see Pineapple\DB\Result::fetchInto()
      */
@@ -210,7 +210,7 @@ class PdoDriver extends Common implements DriverInterface
             }
         } else {
             try {
-                $arr = self::getStatement($result)->fetch(PDO::FETCH_NUM);
+                $arr = self::getStatement($result)->fetch(PDO::FETCH_NUM, null, $rownum);
                 // this exception handle was added as the php docs implied a potential exception, which i have thus
                 // far been unable to reproduce.
                 // @codeCoverageIgnoreStart

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -116,7 +116,6 @@ class PdoDriver extends Common implements DriverInterface
 
         // enable/disable result_buffering in mysql
         // @codeCoverageIgnoreStart
-        // @todo test this *thoroughly*
         if (($this->getPlatform() === 'mysql') && !$this->options['result_buffering']) {
             $queryDriverOptions[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
         }
@@ -250,16 +249,16 @@ class PdoDriver extends Common implements DriverInterface
 
             try {
                 $commitResult = $this->connection->commit();
-                // @todo cannot easily generate a failed transaction commit, don't cover this
                 // @codeCoverageIgnoreStart
+                // cannot easily generate a failed transaction commit, don't cover this
             } catch (PDOException $commitException) {
                 return $this->raiseError(DB::DB_ERROR, null, null, $commitException->getMessage());
                 // @codeCoverageIgnoreEnd
             }
 
             if ($commitResult === false) {
-                // @todo cannot easily generate a failed transaction commit, don't cover this
                 // @codeCoverageIgnoreStart
+                // cannot easily generate a failed transaction commit, don't cover this
                 return $this->raiseError(
                     DB::DB_ERROR,
                     null,
@@ -289,16 +288,16 @@ class PdoDriver extends Common implements DriverInterface
 
             try {
                 $rollbackResult = $this->connection->rollBack();
-                // @todo cannot easily generate a failed transaction rollback, don't cover this
                 // @codeCoverageIgnoreStart
+                // cannot easily generate a failed transaction rollback, don't cover this
             } catch (PDOException $rollbackException) {
                 return $this->raiseError(DB::DB_ERROR, null, null, $rollbackException->getMessage());
                 // @codeCoverageIgnoreEnd
             }
 
             if ($rollbackResult === false) {
-                // @todo cannot easily generate a failed transaction rollback, don't cover this
                 // @codeCoverageIgnoreStart
+                // cannot easily generate a failed transaction rollback, don't cover this
                 return $this->raiseError(
                     DB::DB_ERROR,
                     null,

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -79,12 +79,8 @@ class Result
      */
     public $query;
 
-    /**
-     * The query result created by the driver
-     * @var StatementContainer
-     * @todo make private?
-     */
-    public $result;
+    /** @var StatementContainer The query result created by the driver */
+    private $result;
 
     /**
      * The present row being dealt with
@@ -370,6 +366,16 @@ class Result
     public function getQuery()
     {
         return $this->query;
+    }
+
+    /**
+     * Get the 'result' StatementContainer from the private property
+     *
+     * @return StatementContainer
+     */
+    public function getResult()
+    {
+        return $this->result;
     }
 
     /**

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -118,7 +118,7 @@ class Result
         $this->fetchmode = $dbh->getFetchmode();
         $this->fetchModeObjectClass = $dbh->getFetchModeObjectClass();
         $this->parameters = $dbh->lastParameters;
-        $this->query = $dbh->lastQuery;
+        $this->query = $dbh->getLastQuery();
         $this->result = $result;
         // @todo check line below. i suspect this is not needed
         $this->statement = null; // empty($dbh->lastStatement) ? null : $dbh->lastStatement;

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -116,8 +116,6 @@ class Result
         $this->parameters = $dbh->getLastParameters();
         $this->query = $dbh->getLastQuery();
         $this->result = $result;
-        // @todo check line below. i suspect this is not needed
-        $this->statement = null; // empty($dbh->lastStatement) ? null : $dbh->lastStatement;
         foreach ($options as $key => $value) {
             $this->setOption($key, $value);
         }
@@ -170,7 +168,7 @@ class Result
      */
     public function fetchRow($fetchmode = DB::DB_FETCHMODE_DEFAULT, $rownum = null)
     {
-        // @todo not bitwise ops on a supposedly bitwise fetch mode
+        // @note the author says the FETCHMODE constants are bitwise, but they clearly aren't here
         if ($fetchmode === DB::DB_FETCHMODE_DEFAULT) {
             $fetchmode = $this->fetchmode;
         }
@@ -244,7 +242,7 @@ class Result
      */
     public function fetchInto(&$arr, $fetchmode = DB::DB_FETCHMODE_DEFAULT, $rownum = null)
     {
-        // @todo non-bitwise ops on a supposedly bitwise fetch mode
+        // @note the author says the FETCHMODE constants are bitwise but they clearly aren't here
         if ($fetchmode === DB::DB_FETCHMODE_DEFAULT) {
             $fetchmode = $this->fetchmode;
         }

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -117,7 +117,7 @@ class Result
         $this->dbh = $dbh;
         $this->fetchmode = $dbh->getFetchmode();
         $this->fetchModeObjectClass = $dbh->getFetchModeObjectClass();
-        $this->parameters = $dbh->lastParameters;
+        $this->parameters = $dbh->getLastParameters();
         $this->query = $dbh->getLastQuery();
         $this->result = $result;
         // @todo check line below. i suspect this is not needed

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -379,7 +379,7 @@ class CommonTest extends TestCase
 
         $this->assertEquals(
             'INSERT INTO my_awesome_table (good,bad,ugly) VALUES (\'yes\',\'no\',\'of course\')',
-            $dbh->lastQuery
+            $dbh->getLastQuery()
         );
     }
 

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -1333,4 +1333,12 @@ class CommonTest extends TestCase
         $this->assertInstanceOf(Error::class, $insertId);
         $this->assertEquals(DB::DB_ERROR_UNSUPPORTED, $insertId->getCode());
     }
+
+    public function testChangeDatabase()
+    {
+        $dbh = DB::factory(TestDriver::class);
+        $ret = $dbh->changeDatabase('foo');
+        $this->assertInstanceOf(Error::class, $ret);
+        $this->assertEquals(DB::DB_ERROR_UNSUPPORTED, $ret->getCode());
+    }
 }

--- a/test/DB/Driver/DoctrineDbalTest.php
+++ b/test/DB/Driver/DoctrineDbalTest.php
@@ -340,7 +340,9 @@ class DoctrineDbalTest extends TestCase
 
     public function testAffectedRows()
     {
-        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'the nurse who loved me\'),(\'solaris\')');
+        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'the nurse who loved me\')');
+        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'solaris\')');
+        $this->dbh->query('UPDATE transactiontest SET a = \'the goonies\'');
         $this->assertEquals(2, $this->dbh->affectedRows());
     }
 

--- a/test/DB/Driver/DoctrineDbalTest.php
+++ b/test/DB/Driver/DoctrineDbalTest.php
@@ -431,7 +431,7 @@ class DoctrineDbalTest extends TestCase
                 'table' => 'dbaltest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ]
         ], $tableInfo);
     }
@@ -467,7 +467,7 @@ class DoctrineDbalTest extends TestCase
                 'table' => 'keycasetest',
                 'name' => 'mixedcasecolumn',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ]
         ], $tableInfo);
     }
@@ -485,7 +485,7 @@ class DoctrineDbalTest extends TestCase
                 'table' => 'dbaltest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ],
             'num_fields' => 1,
             'order' => ['a' => 0],
@@ -505,7 +505,7 @@ class DoctrineDbalTest extends TestCase
                 'table' => 'dbaltest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ],
             'num_fields' => 1,
             'ordertable' => [

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -42,6 +42,9 @@ class PdoDriverTest extends TestCase
 
         // testing transacations (empty table)
         'CREATE TABLE transactiontest (a TEXT)',
+
+        // empty table
+        'CREATE TABLE emptytable (a TEXT)',
     ];
 
     /**
@@ -533,5 +536,21 @@ class PdoDriverTest extends TestCase
     {
         $this->dbh->query('INSERT INTO pdotest (a) VALUES (\'lama farmer\')');
         $this->assertEquals(5, $this->dbh->lastInsertId());
+    }
+
+    public function testGetOne()
+    {
+        $data = $this->dbh->getOne('SELECT * FROM pdotest');
+        $this->assertEquals('test1', $data);
+    }
+
+    public function testGetOneWithNoData()
+    {
+        // PLEASE NOTE
+        // AT SOME POINT IN THE FUTURE THIS BEHAVIOUR MAY CHANGE AND THIS TEST MAY FAIL AND REQUIRE REWORKING
+        // YOU HAVE BEEN WARNED
+        // RIGHT NOW THIS TESTS THE EXISTING FUNCTIONALITY
+        $data = $this->dbh->getOne('SELECT * FROM emptytable');
+        $this->assertNull($data);
     }
 }

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -449,7 +449,7 @@ class PdoDriverTest extends TestCase
                 'table' => 'pdotest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ]
         ], $tableInfo);
     }
@@ -485,7 +485,7 @@ class PdoDriverTest extends TestCase
                 'table' => 'keycasetest',
                 'name' => 'mixedcasecolumn',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ]
         ], $tableInfo);
     }
@@ -503,7 +503,7 @@ class PdoDriverTest extends TestCase
                 'table' => 'pdotest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ],
             'num_fields' => 1,
             'order' => ['a' => 0],
@@ -523,7 +523,7 @@ class PdoDriverTest extends TestCase
                 'table' => 'pdotest',
                 'name' => 'a',
                 'type' => 'string',
-                'flags' => [],
+                'flags' => '',
             ],
             'num_fields' => 1,
             'ordertable' => [

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -363,7 +363,9 @@ class PdoDriverTest extends TestCase
 
     public function testAffectedRows()
     {
-        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'the nurse who loved me\'),(\'solaris\')');
+        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'the nurse who loved me\')');
+        $this->dbh->query('INSERT INTO transactiontest (a) VALUES (\'solaris\')');
+        $this->dbh->query('UPDATE transactiontest SET a = \'the goonies\'');
         $this->assertEquals(2, $this->dbh->affectedRows());
     }
 

--- a/test/DB/ResultTest.php
+++ b/test/DB/ResultTest.php
@@ -369,7 +369,7 @@ class ResultTest extends TestCase
 
         // testdriver doesn't implement bound parameters, so the tokeniser expands the query.
         // also, there's no getter to pull the last query out of dbh, so fetch directly.
-        $this->assertEquals('SELECT things FROM a_table WHERE foo = \'bar\'', $dbh->lastQuery);
+        $this->assertEquals('SELECT things FROM a_table WHERE foo = \'bar\'', $dbh->getLastQuery());
     }
 
     public function testNumRowsWithPortabilityQueryFailure()


### PR DESCRIPTION
Changes since 0.3.0:

- some more PSR-2 fixes
- add a `getOne()` test for the `PdoDriver`
- fix a test case so that it works with earlier sqlite versions
- adjust `tableInfo()` output so it matches PEAR DB better
- adjust `tableInfo()` so it only works with the `mysql` platform
- repair query buffering for `PdoDriver` (not supported in `DoctrineDbal` driver)
- add a `changeDatabase()` method to backfill for (yucky) altering of the `$db->_db` to switch databases on the fly
- add accessors for `getResult` in the `Result` class, `getLastQuery` and `getLastQueryParameters` in the driver `Common` class
- fix up the pending `@todo` list
- `DriverInterface` is now method complete
- fix some of the older XML markup in docblocks and change it to markdown

We failed to note in previous release that:

- `getSpecialQuery`
- `getListOf`
- `createSequence` & all other sequence facilities

Had been moved to pineapple-compat. You're advised to get used to life without them or write a polyfill.