### PR TITLE
Send DB_ERROR_UNSUPPORTED if seeking in pdo_mysql

### DIFF
--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -164,6 +164,18 @@ class DoctrineDbal extends Common implements DriverInterface
      */
     public function fetchInto(StatementContainer $result, &$arr, $fetchmode, $rownum = null)
     {
+        // @codeCoverageIgnoreStart
+        // This is not coverable by integration tests
+        if (isset($rownum) && ($rownum !== null) && ($this->getPlatform() === 'mysql')) {
+            return $this->raiseError(
+                DB::DB_ERROR_UNSUPPORTED,
+                null,
+                null,
+                'pdo_mysql does not support cursor seeking'
+            );
+        }
+        // @codeCoverageIgnoreEnd
+
         if ($fetchmode & DB::DB_FETCHMODE_ASSOC) {
             $arr = self::getStatement($result)->fetch(PDO::FETCH_ASSOC, null, $rownum);
             if (($this->options['portability'] & DB::DB_PORTABILITY_LOWERCASE) && $arr) {

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -203,6 +203,18 @@ class PdoDriver extends Common implements DriverInterface
      */
     public function fetchInto(StatementContainer $result, &$arr, $fetchmode, $rownum = null)
     {
+        // @codeCoverageIgnoreStart
+        // This is not coverable by integration tests
+        if (isset($rownum) && ($rownum !== null) && ($this->getPlatform() === 'mysql')) {
+            return $this->raiseError(
+                DB::DB_ERROR_UNSUPPORTED,
+                null,
+                null,
+                'pdo_mysql does not support cursor seeking'
+            );
+        }
+        // @codeCoverageIgnoreEnd
+
         if ($fetchmode & DB::DB_FETCHMODE_ASSOC) {
             $arr = self::getStatement($result)->fetch(PDO::FETCH_ASSOC, null, $rownum);
             if (($this->options['portability'] & DB::DB_PORTABILITY_LOWERCASE) && $arr) {


### PR DESCRIPTION
`pdo_mysql` does not support row seeking and even silently fails to do what is asked of it when requested. As such, we're making it clear that seeking is not possible by returning a `DB_ERROR_UNSUPPORTED` error.