### PR TITLE
DB not aliased in `DriverInterface`, unresolved constants

### DIFF
--- a/src/DB/Driver/DriverInterface.php
+++ b/src/DB/Driver/DriverInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pineapple\DB\Driver;
 
+use Pineapple\DB;
 use Pineapple\DB\StatementContainer;
 
 interface DriverInterface


### PR DESCRIPTION
`DriverInterface` is missing namespace import for `Pineapple\DB`, meaning `DB::DB_*` constants in the interface are nonsensical.