### PR TITLE
Set result buffering options on connection handle

### DIFF
--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -116,8 +116,8 @@ class PdoDriver extends Common implements DriverInterface
 
         // enable/disable result_buffering in mysql
         // @codeCoverageIgnoreStart
-        if (($this->getPlatform() === 'mysql') && !$this->options['result_buffering']) {
-            $queryDriverOptions[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
+        if ($this->getPlatform() === 'mysql') {
+            $this->connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $this->options['result_buffering'] ? true : false);
         }
         // @codeCoverageIgnoreEnd
 


### PR DESCRIPTION
At the moment, we're attempting to set the result buffering options on the statement handle as per the official PHP documentation for pdo_mysql. However, it appears this is wrong. The MySQL documentation on the php-api for pdo_mysql indicate that the option should be set upon the _connection_ handle in order for this to function correctly.

This change fixes this and closes #50 once merged.