### PR TITLE
Add missing namespace alias to catch exceptions

### DIFF
--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -5,6 +5,8 @@ use Pineapple\DB;
 use Pineapple\DB\StatementContainer;
 use Pineapple\DB\Result;
 
+use PDOException;
+
 /**
  * Common methods shared amongst PDO and PDO-alike drivers.
  *


### PR DESCRIPTION
see issue #55 

A missing namespace alias for `PDOException` means when PDO is in exception error more, exceptions aren't caught. The error mechanism may well work but the exception will have hit whatever the default exception handler is by then, so execution has likely come to an untimely end.