### PR TITLE
Test some difficult to test situations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "phpunit/phpunit": "^5.4",
         "ext-pdo_sqlite": "*",
         "doctrine/dbal": ">=2.5",
-        "phpspec/prophecy": "^1.7"
+        "phpspec/prophecy": "^1.7",
+        "mikey179/vfsStream": "^1.6"
     },
     "extra": {
         "branch-alias": {

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -852,15 +852,11 @@ abstract class Common extends Util
             if ($this->prepareTypes[$stmt][$bindPosition] == DB::DB_PARAM_SCALAR) {
                 $realquery .= $this->quoteSmart($value);
             } elseif ($this->prepareTypes[$stmt][$bindPosition] == DB::DB_PARAM_OPAQUE) {
-                $fp = @fopen($value, 'rb');
-                if (!$fp) {
-                    // @codeCoverageIgnoreStart
-                    // this is a pain to test without vfsStream, so skip for now
+                $opaqueData = file_get_contents($value);
+                if ($opaqueData === false) {
                     return $this->raiseError(DB::DB_ERROR_ACCESS_VIOLATION);
-                    // @codeCoverageIgnoreEnd
                 }
-                $realquery .= $this->quoteSmart(fread($fp, filesize($value)));
-                fclose($fp);
+                $realquery .= $this->quoteSmart($opaqueData);
             } else {
                 $realquery .= $value;
             }

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -442,11 +442,8 @@ trait PdoCommonMethods
     {
         try {
             $sequenceValue = $this->connection->lastInsertId($sequence);
-            // can't "generate" a fault in a platform within which sequences are supported, so...
-            // @codeCoverageIgnoreStart
         } catch (PDOException $sequenceException) {
             return $this->raiseError($this->getNativeErrorCode($sequenceException->getCode()));
-            // @codeCoverageIgnoreEnd
         }
 
         // non-exception case error handling here
@@ -455,10 +452,7 @@ trait PdoCommonMethods
             return $sequenceValue;
         }
 
-        // can't "generate" a fault in a platform within which sequences are supported, so...
-        // @codeCoverageIgnoreStart
         return $this->raiseError($this->getNativeErrorCode($this->connection->errorCode()));
-        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -470,8 +464,6 @@ trait PdoCommonMethods
      *               if the feature is not supported by the driver
      *
      * @see Pineapple\DB\Error
-     * @codeCoverageIgnore Skipping coverage because we don't have MySQL
-     *                     integration tests
      */
     public function changeDatabase($name)
     {

--- a/src/DB/Driver/PdoDriver.php
+++ b/src/DB/Driver/PdoDriver.php
@@ -361,7 +361,10 @@ class PdoDriver extends Common implements DriverInterface
      */
     protected static function getStatement(StatementContainer $result)
     {
-        if ($result->getStatementType() === ['type' => 'object', 'class' => PDOStatement::class]) {
+        $statementType = $result->getStatementType();
+        if (($statementType['type'] === 'object') &&
+            ($result->getStatement() instanceof PDOStatement)
+        ) {
             return $result->getStatement();
         }
         throw new DriverException(

--- a/test/DB/Driver/CommonTest.php
+++ b/test/DB/Driver/CommonTest.php
@@ -9,6 +9,7 @@ use Pineapple\DB\Driver\Common;
 use Pineapple\Test\DB\Driver\TestDriver;
 use Pineapple\DB\Exception\FeatureException;
 
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
 // 'Common' is an abstract class so we're going to use our mock TestDriver to stub
@@ -991,6 +992,17 @@ class CommonTest extends TestCase
         $dbh = DB::factory(TestDriver::class);
 
         $result = $dbh->getAll('SELECT foo FROM bar WHERE foo = ?', 'bar');
+        $this->assertEquals(self::$orderedAllData, $result);
+    }
+
+    public function testGetAllWithOpaqueParam()
+    {
+        $dbh = DB::factory(TestDriver::class);
+
+        $root = vfsStream::setup();
+        file_put_contents($root->url() . '/opaquedata.txt', 'bum');
+
+        $result = $dbh->getAll('SELECT foo FROM bar WHERE foo = &', $root->url() . '/opaquedata.txt');
         $this->assertEquals(self::$orderedAllData, $result);
     }
 

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -570,6 +570,8 @@ class PdoDriverTest extends TestCase
 
         // stub the pdo connection
         $pStubPdo = $prophet->prophesize(PDO::class);
+        $pStubPdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true)
+            ->shouldBeCalled();
         $pStubPdo->getAttribute(PDO::ATTR_DRIVER_NAME)
             ->willReturn('mysql')
             ->shouldBeCalled();

--- a/test/DB/Driver/PdoDriverTest.php
+++ b/test/DB/Driver/PdoDriverTest.php
@@ -10,8 +10,10 @@ use Pineapple\Test\DB\Driver\TestDriver;
 use Pineapple\DB\Exception\StatementException;
 use Pineapple\DB\Exception\DriverException;
 
+use Prophecy\Prophet;
 use PDO;
 use PDOStatement;
+use PDOException;
 
 use PHPUnit\Framework\TestCase;
 
@@ -554,5 +556,111 @@ class PdoDriverTest extends TestCase
         // RIGHT NOW THIS TESTS THE EXISTING FUNCTIONALITY
         $data = $this->dbh->getOne('SELECT * FROM emptytable');
         $this->assertNull($data);
+    }
+
+    /** @test */
+    public function itCanChangeDatabase()
+    {
+        $prophet = new Prophet;
+
+        // stub the statement class
+        $pStubStatement = $prophet->prophesize(PDOStatement::class);
+        $pStubStatement->execute()
+            ->shouldBeCalled();
+
+        // stub the pdo connection
+        $pStubPdo = $prophet->prophesize(PDO::class);
+        $pStubPdo->getAttribute(PDO::ATTR_DRIVER_NAME)
+            ->willReturn('mysql')
+            ->shouldBeCalled();
+        $pStubPdo->prepare('USE `myTestValue`', [])
+            ->willReturn($pStubStatement->reveal())
+            ->shouldBeCalled();
+
+        // build the db object and change database
+        $db = DB::factory(PdoDriver::class);
+        $db->setConnectionHandle($pStubPdo->reveal());
+
+        // this is what we came here to test
+        $db->changeDatabase('myTestValue');
+
+        // check that everything that should have been called has been so
+        $prophet->checkPredictions();
+    }
+
+    /** @test */
+    public function itFailsWhenChangingDatabaseOnAnUnsupportedPlatform()
+    {
+        $prophet = new Prophet;
+
+        // stub the pdo connection
+        $pStubPdo = $prophet->prophesize(PDO::class);
+        $pStubPdo->getAttribute(PDO::ATTR_DRIVER_NAME)
+            ->willReturn('unsupported')
+            ->shouldBeCalled();
+
+        // build the db object and change database
+        $db = DB::factory(PdoDriver::class);
+        $db->setConnectionHandle($pStubPdo->reveal());
+
+        // this is what we came here to test
+        $result = $db->changeDatabase('myTestValue');
+        $this->assertInstanceOf(Error::class, $result);
+        $this->assertEquals(DB::DB_ERROR_UNSUPPORTED, $result->getCode());
+
+        // check that everything that should have been called has been so
+        $prophet->checkPredictions();
+    }
+
+    /** @test */
+    public function itFailsWhenLastInsertIdThrowsAnException()
+    {
+        $prophet = new Prophet;
+
+        // stub the pdo connection
+        $pStubPdo = $prophet->prophesize(PDO::class);
+        $pStubPdo->lastInsertId(null)
+            ->willThrow(new PDOException('Not supported by platform'))
+            ->shouldBeCalled();
+
+        // build the db object and change database
+        $db = DB::factory(PdoDriver::class);
+        $db->setConnectionHandle($pStubPdo->reveal());
+
+        // this is what we came here to test
+        $result = $db->lastInsertId();
+        $this->assertInstanceOf(Error::class, $result);
+        $this->assertEquals(DB::DB_ERROR, $result->getCode());
+
+        // check that everything that should have been called has been so
+        $prophet->checkPredictions();
+    }
+
+    /** @test */
+    public function itFailsWhenLastInsertIdFails()
+    {
+        $prophet = new Prophet;
+
+        // stub the pdo connection
+        $pStubPdo = $prophet->prophesize(PDO::class);
+        $pStubPdo->lastInsertId(null)
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        $pStubPdo->errorCode()
+            ->willReturn('01P01')
+            ->shouldBeCalled();
+
+        // build the db object and change database
+        $db = DB::factory(PdoDriver::class);
+        $db->setConnectionHandle($pStubPdo->reveal());
+
+        // this is what we came here to test
+        $result = $db->lastInsertId();
+        $this->assertInstanceOf(Error::class, $result);
+        $this->assertEquals(DB::DB_ERROR_UNSUPPORTED, $result->getCode());
+
+        // check that everything that should have been called has been so
+        $prophet->checkPredictions();
     }
 }


### PR DESCRIPTION
This branch incorporates a number of tests, thanks to Prophecy, which test difficult to reproduce situations in integration tests. Notably, last insert IDs and on-the-fly database changes. More tests will follow, but this code will help bolster an error situation and I want to produce a bugfix release.