### PR TITLE
Rename vfsStream to vfsstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor/
 /composer.lock
 /coverage/
-.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "ext-pdo_sqlite": "*",
         "doctrine/dbal": ">=2.5",
         "phpspec/prophecy": "^1.7",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     }
 }


### PR DESCRIPTION
As per issue #61 - composer 2.0 will break when dependency titles have capitals, so fix this to prevent future breakage.