### PR TITLE
Prep for 0.3.x release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor/
 /composer.lock
 /coverage/
-.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-dist: trusty
+dist: xenial
 
 language: php
 php:
+  - 7.3
+  - 7.2
   - 7.1
   - 7.0
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "ext-pdo_sqlite": "*",
         "doctrine/dbal": ">=2.5",
         "phpspec/prophecy": "^1.7",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsstream": "^1.6"
     }
 }

--- a/src/DB/Driver/Common.php
+++ b/src/DB/Driver/Common.php
@@ -44,6 +44,16 @@ use stdClass;
  */
 abstract class Common extends Util
 {
+    // placeholder markers
+    const PLACEHOLDER_AUTOQUOTED = '?';
+    const PLACEHOLDER_FILENAME = '&';
+    const PLACEHOLDER_VERBATIM = '!';
+
+    // driver platforms
+    const PLATFORM_MYSQL = 'mysql';
+    const PLATFORM_PGSQL = 'pgsql';
+    const PLATFORM_SQLITE = 'sqlite';
+
     /** @var integer The current default fetch mode */
     protected $fetchmode = DB::DB_FETCHMODE_ORDERED;
 
@@ -618,13 +628,13 @@ abstract class Common extends Util
 
         foreach ($tokens as $val) {
             switch ($val) {
-                case '?':
+                case self::PLACEHOLDER_AUTOQUOTED:
                     $types[$token++] = DB::DB_PARAM_SCALAR;
                     break;
-                case '&':
+                case self::PLACEHOLDER_FILENAME:
                     $types[$token++] = DB::DB_PARAM_OPAQUE;
                     break;
-                case '!':
+                case self::PLACEHOLDER_VERBATIM:
                     $types[$token++] = DB::DB_PARAM_MISC;
                     break;
                 default:
@@ -852,7 +862,7 @@ abstract class Common extends Util
             if ($this->prepareTypes[$stmt][$bindPosition] == DB::DB_PARAM_SCALAR) {
                 $realquery .= $this->quoteSmart($value);
             } elseif ($this->prepareTypes[$stmt][$bindPosition] == DB::DB_PARAM_OPAQUE) {
-                $opaqueData = file_get_contents($value);
+                $opaqueData = @file_get_contents($value);
                 if ($opaqueData === false) {
                     return $this->raiseError(DB::DB_ERROR_ACCESS_VIOLATION);
                 }

--- a/src/DB/Driver/Components/PdoCommonMethods.php
+++ b/src/DB/Driver/Components/PdoCommonMethods.php
@@ -4,6 +4,7 @@ namespace Pineapple\DB\Driver\Components;
 use Pineapple\DB;
 use Pineapple\DB\StatementContainer;
 use Pineapple\DB\Result;
+use Pineapple\DB\Driver\Common;
 
 use PDOException;
 
@@ -213,9 +214,9 @@ trait PdoCommonMethods
          * we could also just strip single quotes.
          */
         switch ($this->getPlatform()) {
-            case 'mysql':
-            case 'pgsql':
-            case 'sqlite':
+            case Common::PLATFORM_MYSQL:
+            case Common::PLATFORM_PGSQL:
+            case Common::PLATFORM_SQLITE:
                 $quotedString = $this->connection->quote($str);
 
                 if ($quotedString === false) {
@@ -470,13 +471,11 @@ trait PdoCommonMethods
     public function changeDatabase($name)
     {
         switch ($this->getPlatform()) {
-            case 'mysql':
+            case Common::PLATFORM_MYSQL:
                 return $this->simpleQuery('USE ' . $this->quoteIdentifier($name));
-                break;
 
             default:
                 return $this->raiseError(DB::DB_ERROR_UNSUPPORTED);
-                break;
         }
     }
 }

--- a/src/DB/Driver/DoctrineDbal.php
+++ b/src/DB/Driver/DoctrineDbal.php
@@ -11,7 +11,7 @@ use Pineapple\DB\Driver\Components\PdoCommonMethods;
 
 use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver\Statement as DBALStatement;
-use Doctrine\DBAL\Exception\DriverException as DBALDriverException;
+use Doctrine\DBAL\DBALException as DBALException;
 use Doctrine\DBAL\ConnectionException as DBALConnectionException;
 
 use PDO;
@@ -126,7 +126,7 @@ class DoctrineDbal extends Common implements DriverInterface
 
         try {
             $statement = $this->connection->query($query);
-        } catch (DBALDriverException $exception) {
+        } catch (DBALException $exception) {
             return $this->raiseError(DB::DB_ERROR, null, null, $exception->getMessage());
         }
 

--- a/src/DB/Result.php
+++ b/src/DB/Result.php
@@ -23,6 +23,9 @@ use stdClass;
  */
 class Result
 {
+    const KEY_LIMIT_FROM = 'limit_from';
+    const KEY_LIMIT_COUNT = 'limit_count';
+
     /**
      * Should results be freed automatically when there are no more rows?
      * @var boolean
@@ -130,11 +133,11 @@ class Result
     public function setOption($key, $value = null)
     {
         switch ($key) {
-            case 'limit_from':
+            case self::KEY_LIMIT_FROM:
                 $this->limitFrom = $value;
                 break;
 
-            case 'limit_count':
+            case self::KEY_LIMIT_COUNT:
                 $this->limitCount = $value;
                 break;
         }

--- a/src/DB/StatementContainer.php
+++ b/src/DB/StatementContainer.php
@@ -114,16 +114,17 @@ class StatementContainer
         }
 
         switch (gettype($this->statement)) {
-            case 'object':
+            case gettype($this):
                 return [
                     'type' => 'object',
                     'class' => get_class($this->statement),
                 ];
 
+            // not easy to get a 'resource' label programmatically
             case 'resource':
                 return ['type' => 'resource'];
 
-            case 'array':
+            case gettype([]):
                 return ['type' => 'array'];
         }
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -276,8 +276,7 @@ class Exception extends \Exception
             foreach ($this->cause as $cause) {
                 if ($cause instanceof self) {
                     $cause->getCauseMessage($causes);
-                } elseif (true && ($cause instanceof \Exception)) {
-                    // apologies for true above, it's a temporary hack as phpunit omits it from code coverage.
+                } elseif ($cause instanceof \Exception) {
                     $causes[] = [
                         'class' => get_class($cause),
                         'message' => $cause->getMessage(),
@@ -390,24 +389,24 @@ class Exception extends \Exception
             if (!empty($v['args'])) {
                 foreach ($v['args'] as $arg) {
                     switch (gettype($arg)) {
-                        case 'NULL':
+                        case gettype(null):
                             $args[] = 'null';
                             break;
 
-                        case 'array':
+                        case gettype([]):
                             $args[] = 'Array';
                             break;
 
-                        case 'object':
+                        case gettype($this):
                             $args[] = 'Object(' . get_class($arg) . ')';
                             break;
 
-                        case 'boolean':
+                        case gettype(true):
                             $args[] = $arg ? 'true' : 'false';
                             break;
 
-                        case 'integer':
-                        case 'double':
+                        case gettype((int) 1):
+                        case gettype((double) 1):
                             $args[] = $arg;
                             break;
 

--- a/test/DBTest.php
+++ b/test/DBTest.php
@@ -28,6 +28,13 @@ class DBTest extends TestCase
         $this->assertInstanceOf(Error::class, $dbh);
     }
 
+    /** @test */
+    public function itPassesErrorsBackWhenAnOptionIsInvalid()
+    {
+        $dbh = DB::factory(TestDriver::class, ['favourite_fruit' => 'beans']);
+        $this->assertInstanceOf(Error::class, $dbh);
+    }
+
     public function testIsConnection()
     {
         $dbh = DB::factory(TestDriver::class);

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -13,6 +13,13 @@ class ErrorTest extends TestCase
     private $errors = [];
     private $callbackMessageTrap = null;
 
+    /** @after */
+    public function resetMonkey()
+    {
+        MonkeyPatching::$dontThrow = false;
+        MonkeyPatching::$unthrownException = null;
+    }
+
     public function testConstruct()
     {
         $error = new Error();
@@ -192,10 +199,10 @@ class ErrorTest extends TestCase
 
     public function testToStringWithTrigger()
     {
-        new MonkeyPatching(); // patch trigger_error and suchlike
-        $this->expectException(MonkeyTriggerErrorException::class);
-        $this->expectExceptionMessage('test trigger error');
+        new MonkeyPatching(true); // patch trigger_error and suchlike but don't throw an exception
         $error = new Error('test trigger error', null, Util::PEAR_ERROR_TRIGGER);
+        $this->assertInstanceOf(MonkeyTriggerErrorException::class, MonkeyPatching::$unthrownException);
+        $this->assertEquals('test trigger error', MonkeyPatching::$unthrownException->getMessage());
         $this->assertEquals('[' . strtolower(Error::class) . ': message="test trigger error" code=0 mode=trigger level=notice prefix="" info=""]', $error->toString());
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -313,12 +313,12 @@ class ExceptionTest extends TestCase
         $this->assertRegExp('/^' . preg_quote(Exception::class) . ': you fried cyclops. in/', $exceptionString);
     }
 
-    public function backtraceFodder(array $fodder, $food)
+    public function backtraceFodder($fodder, $food)
     {
         if (is_callable($food)) {
             call_user_func($food);
         }
-        if (!empty($fodder)) {
+        if (!empty($fodder) && is_array($fodder)) {
             $nextFood = array_shift($fodder);
             $this->backtraceFodder($fodder, $nextFood);
         }

--- a/test/MonkeyPatching.php
+++ b/test/MonkeyPatching.php
@@ -5,16 +5,27 @@ namespace Pineapple\Test;
 // namespaces below this test ('use' aliases but does not trigger loading)
 class MonkeyPatching
 {
-    // the class - it does nothing! the action is below.
+    public static $dontThrow;
+    public static $unthrownException;
+
+    public function __construct($dontThrow = false)
+    {
+        self::$dontThrow = $dontThrow;
+    }
 }
 
 namespace Pineapple;
 
 // psr-2 dislikes 'use' after a second namespace declaration
 use Pineapple\Test\Exception\MonkeyTriggerErrorException;
+use Pineapple\Test\MonkeyPatching;
 
 // monkey-patch trigger_error
 function trigger_error($message, $code)
 {
-    throw new MonkeyTriggerErrorException($message, $code);
+    if (MonkeyPatching::$dontThrow === false) {
+        throw new MonkeyTriggerErrorException($message, $code);
+    }
+
+    MonkeyPatching::$unthrownException = new MonkeyTriggerErrorException($message, $code);
 }


### PR DESCRIPTION
Changelog:
- Catch DBAL exception instead of connection exception (thanks to @marty-crane)
- Travis runs against PHP from versions 5.6 -> 7.3 now
- vfsStream dependency fixed to remove warnings regarding Composer 2.0
- Suppress warning generation when opaque file insertion occurs on an unreadable file; use Pineapple error handling
- Test coverage back up at 100% (codeCoverageIgnore still in effect but will be reduced in future)